### PR TITLE
Made prefix dispatch_message public.

### DIFF
--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -10,6 +10,9 @@ pub use builder::*;
 use crate::serenity_prelude as serenity;
 use crate::*;
 
+/// Manually dispatch a message with the prefix framework.
+pub use prefix::dispatch_message;
+
 async fn check_permissions<U, E>(
     ctx: crate::Context<'_, U, E>,
     required_permissions: serenity::Permissions,

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -10,7 +10,6 @@ pub use builder::*;
 use crate::serenity_prelude as serenity;
 use crate::*;
 
-/// Manually dispatch a message with the prefix framework.
 pub use prefix::dispatch_message;
 
 async fn check_permissions<U, E>(

--- a/src/framework/prefix.rs
+++ b/src/framework/prefix.rs
@@ -200,7 +200,9 @@ where
     Ok(first_matching_command)
 }
 
-/// Returns
+/// Manually dispatches a message with the prefix framework.
+///
+/// Returns:
 /// - Ok(()) if a command was successfully dispatched and run
 /// - Err(None) if no command was run but no error happened
 /// - Err(Some(error: UserError)) if any user code yielded an error


### PR DESCRIPTION
Here's a random example as to why this may be useful.

```rust
/// Runs the command in a message as if you did.
#[poise::command(context_menu_command = "Run for yourself")]
async fn run_yourself(
    ctx: Context<'_>,
    #[description = "Command message to run (enter a link or ID)"] mut msg: Message,
) -> Result<(), Error> {
    msg.author = ctx.author().clone();
    msg.id.0 = ctx.id();

    if let Err(e) = poise::dispatch_message(ctx.framework(), ctx.discord(), &msg, false).await {
        match e {
            Some((err, _ctx)) => {
                poise::say_reply(ctx, "There was an error running the command.").await?;
                return Err(err);
            }
            None => {
                poise::say_reply(ctx, "This message is not a bot command.").await?;
                return Ok(());
            }
        }
    }

    poise::say_reply(ctx, &format!("Successfully ran command: `{}`", msg.content)).await?;

    Ok(())
}
```

	modified:   src/framework/mod.rs