### PR TITLE
Re-run commands on track_edits only if the content is different.

### DIFF
--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -262,14 +262,18 @@ impl<U, E> Framework<U, E> {
                 if let Some(edit_tracker) = &self.options.prefix_options.edit_tracker {
                     let msg = edit_tracker.write().process_message_update(event);
 
-                    if let Err(Some((err, ctx))) =
-                        prefix::dispatch_message(self, &ctx, &msg, true).await
-                    {
-                        (self.options.on_error)(
-                            err,
-                            crate::ErrorContext::Command(crate::CommandErrorContext::Prefix(ctx)),
-                        )
-                        .await;
+                    if let Some(msg) = msg {
+                        if let Err(Some((err, ctx))) =
+                            prefix::dispatch_message(self, &ctx, &msg, true).await
+                        {
+                            (self.options.on_error)(
+                                err,
+                                crate::ErrorContext::Command(crate::CommandErrorContext::Prefix(
+                                    ctx,
+                                )),
+                            )
+                            .await;
+                        }
                     }
                 }
             }

--- a/src/prefix/track_edits.rs
+++ b/src/prefix/track_edits.rs
@@ -68,22 +68,34 @@ impl EditTracker {
 
     /// Returns a copy of a newly up-to-date cached message, or a brand new generated message when
     /// not in cache
+    ///
+    /// Returns None if the command shouldn't be re-run, e.g. if the message content stayed the
+    /// same
     pub fn process_message_update(
         &mut self,
         user_msg_update: &serenity::MessageUpdateEvent,
     ) -> Option<serenity::Message> {
-        match self.cache.iter_mut().find(|(user_msg, _)| {
-            if let Some(ref edit_content) = user_msg_update.content {
-                user_msg.id == user_msg_update.id && &user_msg.content != edit_content
-            } else {
-                false
-            }
-        }) {
+        match self
+            .cache
+            .iter_mut()
+            .find(|(user_msg, _)| user_msg.id == user_msg_update.id)
+        {
             Some((user_msg, _)) => {
+                // If message content didn't change, don't re-run command
+                match &user_msg_update.content {
+                    Some(content) if content == user_msg.content => return None,
+                    None => return None,
+                    _ => {}
+                }
+
                 update_message(user_msg, user_msg_update.clone());
                 Some(user_msg.clone())
             }
-            None => None,
+            None => {
+                let mut user_msg = serenity::CustomMessage::new().build();
+                update_message(&mut user_msg, user_msg_update.clone());
+                user_msg
+            }
         }
     }
 

--- a/src/prefix/track_edits.rs
+++ b/src/prefix/track_edits.rs
@@ -83,7 +83,7 @@ impl EditTracker {
             Some((user_msg, _)) => {
                 // If message content didn't change, don't re-run command
                 match &user_msg_update.content {
-                    Some(content) if content == user_msg.content => return None,
+                    Some(content) if content == &user_msg.content => return None,
                     None => return None,
                     _ => {}
                 }
@@ -94,7 +94,7 @@ impl EditTracker {
             None => {
                 let mut user_msg = serenity::CustomMessage::new().build();
                 update_message(&mut user_msg, user_msg_update.clone());
-                user_msg
+                Some(user_msg)
             }
         }
     }

--- a/src/prefix/track_edits.rs
+++ b/src/prefix/track_edits.rs
@@ -71,21 +71,19 @@ impl EditTracker {
     pub fn process_message_update(
         &mut self,
         user_msg_update: &serenity::MessageUpdateEvent,
-    ) -> serenity::Message {
-        match self
-            .cache
-            .iter_mut()
-            .find(|(user_msg, _)| user_msg.id == user_msg_update.id)
-        {
+    ) -> Option<serenity::Message> {
+        match self.cache.iter_mut().find(|(user_msg, _)| {
+            if let Some(ref edit_content) = user_msg_update.content {
+                user_msg.id == user_msg_update.id && &user_msg.content != edit_content
+            } else {
+                false
+            }
+        }) {
             Some((user_msg, _)) => {
                 update_message(user_msg, user_msg_update.clone());
-                user_msg.clone()
+                Some(user_msg.clone())
             }
-            None => {
-                let mut user_msg = serenity::CustomMessage::new().build();
-                update_message(&mut user_msg, user_msg_update.clone());
-                user_msg
-            }
+            None => None,
         }
     }
 


### PR DESCRIPTION
Sometimes, a message could get edited without it's content being modified, making the command get re-invoked uselessly, or unexpectedly, like for example if an embed is removed.

It could also end in an infinite loop if the message edit happened in the command itself, like for example, removing the embed of the message:

```rust
    if let poise::Context::Prefix(pctx) = ctx {
        pctx
            .discord
            .http
            .edit_message(
                pctx.msg.channel_id.0,
                pctx.msg.id.0,
                &serde_json::json!({"flags" : 4}),
            )
            .await?
    }
```

	modified:   src/framework/mod.rs
	modified:   src/prefix/track_edits.rs