### PR TITLE
Allow to ignore non-cached messages on the edit tracker

### DIFF
--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -260,7 +260,10 @@ impl<U, E> Framework<U, E> {
             }
             Event::MessageUpdate { event, .. } => {
                 if let Some(edit_tracker) = &self.options.prefix_options.edit_tracker {
-                    let msg = edit_tracker.write().process_message_update(event);
+                    let msg = edit_tracker.write().process_message_update(
+                        event,
+                        self.options().prefix_options.ignore_edit_tracker_cache,
+                    );
 
                     if let Some(msg) = msg {
                         if let Err(Some((err, ctx))) =

--- a/src/prefix/structs.rs
+++ b/src/prefix/structs.rs
@@ -181,6 +181,10 @@ pub struct PrefixFrameworkOptions<U, E> {
     /// If Some, the framework will react to message edits by editing the corresponding bot response
     /// with the new result.
     pub edit_tracker: Option<parking_lot::RwLock<super::EditTracker>>,
+    /// Wether or not to ignore message edits on messages outside the cache.
+    /// This can happen if the message edit happens while the command is being invoked, or the
+    /// original message wasn't a command.
+    pub ignore_edit_tracker_cache: bool,
     /// Whether to broadcast a typing indicator while executing this commmand's action.
     pub broadcast_typing: BroadcastTypingBehavior,
     /// Whether commands in messages emitted by the bot itself should be executed as well.
@@ -209,6 +213,7 @@ impl<U, E> Default for PrefixFrameworkOptions<U, E> {
             mention_as_prefix: true,
             command_check: |_| Box::pin(async { Ok(true) }),
             edit_tracker: None,
+            ignore_edit_tracker_cache: false,
             broadcast_typing: BroadcastTypingBehavior::None,
             execute_self_messages: false,
             case_insensitive_commands: true,

--- a/src/prefix/track_edits.rs
+++ b/src/prefix/track_edits.rs
@@ -75,11 +75,13 @@ impl EditTracker {
         &mut self,
         user_msg_update: &serenity::MessageUpdateEvent,
     ) -> Option<serenity::Message> {
-        match self
-            .cache
-            .iter_mut()
-            .find(|(user_msg, _)| user_msg.id == user_msg_update.id)
-        {
+        match self.cache.iter_mut().find(|(user_msg, _)| {
+            if let Some(ref edit_content) = user_msg_update.content {
+                user_msg.id == user_msg_update.id && &user_msg.content != edit_content
+            } else {
+                false
+            }
+        }) {
             Some((user_msg, _)) => {
                 // If message content didn't change, don't re-run command
                 match &user_msg_update.content {


### PR DESCRIPTION
Fix an issue introduced by not testing the last 2 commits of #16 optionally while a solution that always works is finished.

	modified:   src/framework/mod.rs
	modified:   src/prefix/structs.rs
	modified:   src/prefix/track_edits.rs