### PR TITLE
Make commands identifyable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ serde_json = "1" # needed for interacting with some parts of the Discord API
 poise_macros = { path = "macros" }
 async-trait = "0.1.48" # PopArgumentAsync trait
 regex = "1.5.4" # prefix
-arc-swap = "1" # shard manager
 uid = "0.1" # no deps, no_std, unique ids, for CommandId
 
 [dependencies.serenity]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ poise_macros = { path = "macros" }
 async-trait = "0.1.48" # PopArgumentAsync trait
 regex = "1.5.4" # prefix
 arc-swap = "1" # shard manager
+uid = "0.1" # no deps, no_std, unique ids, for CommandId
 
 [dependencies.serenity]
 default-features = false

--- a/macros/src/command/prefix.rs
+++ b/macros/src/command/prefix.rs
@@ -104,7 +104,8 @@ pub fn generate_prefix_command_spec(
                 hide_in_help: #hide_in_help,
                 required_permissions: #required_permissions,
                 owners_only: #owners_only,
-            }
+            },
+            id: Default::default(),
         }
     })
 }

--- a/macros/src/command/slash.rs
+++ b/macros/src/command/slash.rs
@@ -111,6 +111,7 @@ pub fn generate_slash_command_spec(
                 inner(ctx.into(), #( #param_names, )*).await
             }),
             options: #options,
+            id: Default::default(),
         }
     })
 }
@@ -137,6 +138,7 @@ pub fn generate_context_menu_command_spec(
                 Box::pin(async move { inner(ctx.into(), value).await })
             }),
             options: #options,
+            id: Default::default(),
         }
     })
 }

--- a/src/prefix/structs.rs
+++ b/src/prefix/structs.rs
@@ -88,6 +88,8 @@ pub struct PrefixCommand<U, E> {
     pub action: for<'a> fn(PrefixContext<'a, U, E>, args: &'a str) -> BoxFuture<'a, Result<(), E>>,
     /// Optional data to change this command's behavior.
     pub options: PrefixCommandOptions<U, E>,
+    /// The command ID
+    pub id: crate::CommandId,
 }
 
 /// Includes a command, plus metadata like associated sub-commands or category.

--- a/src/slash/structs.rs
+++ b/src/slash/structs.rs
@@ -285,10 +285,10 @@ impl<'a, U, E> ApplicationCommand<'a, U, E> {
     }
 
     /// Yield the command ID.
-    pub fn id(self) -> crate::CommandId {
+    pub fn id(&self) -> &crate::CommandId {
         match self {
-            Self::Slash(cmd) => cmd.id.clone(),
-            Self::ContextMenu(cmd) => cmd.id.clone(),
+            Self::Slash(cmd) => &cmd.id,
+            Self::ContextMenu(cmd) => &cmd.id,
         }
     }
 

--- a/src/slash/structs.rs
+++ b/src/slash/structs.rs
@@ -124,6 +124,8 @@ pub struct SlashCommand<U, E> {
     ) -> BoxFuture<'a, Result<(), E>>,
     /// Further configuration
     pub options: ApplicationCommandOptions<U, E>,
+    /// The command ID
+    pub id: crate::CommandId,
 }
 
 /// A single slash command or slash command group
@@ -229,6 +231,8 @@ pub struct ContextMenuCommand<U, E> {
     pub options: ApplicationCommandOptions<U, E>,
     /// The target and action of the context menu entry
     pub action: ContextMenuCommandAction<U, E>,
+    /// The command ID
+    pub id: crate::CommandId,
 }
 
 /// Defines any application command, including subcommands if supported by the application command
@@ -277,6 +281,14 @@ impl<'a, U, E> ApplicationCommand<'a, U, E> {
         match self {
             Self::Slash(cmd) => cmd.name,
             Self::ContextMenu(cmd) => cmd.name,
+        }
+    }
+
+    /// Yield the command ID.
+    pub fn id(self) -> crate::CommandId {
+        match self {
+            Self::Slash(cmd) => cmd.id.clone(),
+            Self::ContextMenu(cmd) => cmd.id.clone(),
         }
     }
 

--- a/src/slash/structs.rs
+++ b/src/slash/structs.rs
@@ -203,6 +203,14 @@ impl<U, E> SlashCommandMeta<U, E> {
         }
         interaction
     }
+
+    /// Returns the Command or Group name.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::CommandGroup { name, .. } => name,
+            Self::Command(command) => command.name,
+        }
+    }
 }
 
 /// Possible actions that a context menu entry can have

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -177,6 +177,21 @@ impl<U, E> Context<'_, U, E> {
             }
         }
     }
+
+    /// Retunrs the name of the command.
+    ///
+    /// Can return None if the prefix context command field is None.
+    pub fn command_name(&self) -> Option<&'static str> {
+        match self {
+            Self::Prefix(ctx) => Some(ctx.command?.name),
+            Self::Application(ctx) => {
+                match ctx.command {
+                    crate::ApplicationCommand::Slash(cmd) => Some(cmd.name),
+                    crate::ApplicationCommand::ContextMenu(cmd) => Some(cmd.name),
+                }
+            }
+        }
+    }
 }
 
 /// A reference to either a prefix or application command.

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -409,7 +409,8 @@ pub struct FrameworkOptions<U, E> {
     pub prefix_options: crate::PrefixFrameworkOptions<U, E>,
     /// User IDs which are allowed to use owners_only commands
     pub owners: std::collections::HashSet<serenity::UserId>,
-    /// Internal field to count the number of assigned Command IDs
+    /// The number of registered commands. This counts individual commands, and will not count
+    /// individual variants if they can be executed multiple ways.
     pub id_count: usize,
 }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -311,7 +311,7 @@ pub struct CommandBuilder<U, E> {
     prefix_command: Option<crate::PrefixCommandMeta<U, E>>,
     slash_command: Option<crate::SlashCommandMeta<U, E>>,
     context_menu_command: Option<crate::ContextMenuCommand<U, E>>,
-    name: Option<String>,
+    identifying_name: Option<String>,
 }
 
 impl<U, E> CommandBuilder<U, E> {
@@ -323,9 +323,9 @@ impl<U, E> CommandBuilder<U, E> {
         self
     }
 
-    /// Assign a name to this command, which will be used as the [`crate::CommandId`] name.
-    pub fn name(&mut self, name: String) -> &mut Self {
-        self.name = Some(name);
+    /// Assign a name to this command, which will be used as the [`crate::CommandId`] identifying_name.
+    pub fn identifying_name(&mut self, name: String) -> &mut Self {
+        self.identifying_name = Some(name);
         self
     }
 
@@ -353,11 +353,11 @@ impl<U, E> CommandBuilder<U, E> {
             prefix_command,
             slash_command,
             context_menu_command,
-            name: None,
+            identifying_name: None,
         };
         meta_builder(&mut builder);
 
-        let name = if let Some(name) = builder.name {
+        let identifying_name = if let Some(name) = builder.identifying_name {
             name
         } else if let Some(ref prefix_command) = builder.prefix_command {
             prefix_command.command.name.to_string()
@@ -371,7 +371,7 @@ impl<U, E> CommandBuilder<U, E> {
 
         let command_id = CommandId {
             id: UniqueId::new(),
-            name,
+            identifying_name,
         };
 
         // Nested if's to compile on Rust 1.48
@@ -459,7 +459,7 @@ pub struct FrameworkOptions<U, E> {
     /// // Will only have one ID, and the name will be "new_name", but the command invoke will
     /// // still be "name"
     /// #[command(slash_command, context_menu_command = "New Name", rename="name")]
-    /// options.command(command_function(), |f| f.name("new_name".to_string()));
+    /// options.command(command_function(), |f| f.identifying_name("new_name".to_string()));
     ///
     /// // Will only have one ID, and the name will be "Name"
     /// #[command(context_menu_command = "Name")]
@@ -469,7 +469,7 @@ pub struct FrameworkOptions<U, E> {
     /// #[command(prefix_command, slash_command, rename="name")]
     /// options.command(command_function(), |f| {
     ///     f.subcommand(command_function(), |f| {
-    ///         f.name("name".to_string())
+    ///         f.identifying_name("name".to_string())
     ///     })
     /// });
     /// ```
@@ -520,11 +520,11 @@ impl<U, E> FrameworkOptions<U, E> {
             prefix_command,
             slash_command,
             context_menu_command,
-            name: None,
+            identifying_name: None,
         };
         meta_builder(&mut builder);
 
-        let name = if let Some(name) = builder.name {
+        let identifying_name = if let Some(name) = builder.identifying_name {
             name
         } else if let Some(ref prefix_command) = builder.prefix_command {
             prefix_command.command.name.to_string()
@@ -538,7 +538,7 @@ impl<U, E> FrameworkOptions<U, E> {
 
         let command_id = CommandId {
             id: UniqueId::new(),
-            name,
+            identifying_name,
         };
 
         self.command_ids.push(command_id.clone());
@@ -658,5 +658,5 @@ pub struct CommandId {
     /// A unique name for the command, configurable when registered, otherwise it will use the
     /// Prefix name if present, otherwise the Application Command if present and at last, the
     /// ContextNenu name.
-    pub name: String,
+    pub identifying_name: String,
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -447,6 +447,32 @@ pub struct FrameworkOptions<U, E> {
     pub owners: std::collections::HashSet<serenity::UserId>,
     /// The IDs of the registered commands. This has individual commands, and will not have
     /// individual variants if they can be executed multiple ways.
+    ///
+    /// Example:
+    /// ```rust, ignore
+    /// // Will only have one ID
+    /// #[command(prefix_command, slash_command)]
+    ///
+    /// // Will only have one ID, and the name will be "name"
+    /// #[command(slash_command, context_menu_command = "New Name", rename="name")]
+    ///
+    /// // Will only have one ID, and the name will be "new_name", but the command invoke will
+    /// // still be "name"
+    /// #[command(slash_command, context_menu_command = "New Name", rename="name")]
+    /// options.command(command_function(), |f| f.name("new_name".to_string()));
+    ///
+    /// // Will only have one ID, and the name will be "Name"
+    /// #[command(context_menu_command = "Name")]
+    ///
+    /// // Will only have two IDs, the name of `/name` will be `name`, and the name of
+    /// // `/name name` will be `name2`, both with different IDs.
+    /// #[command(prefix_command, slash_command, rename="name")]
+    /// options.command(command_function(), |f| {
+    ///     f.subcommand(command_function(), |f| {
+    ///         f.name("name".to_string())
+    ///     })
+    /// });
+    /// ```
     pub command_ids: Vec<CommandId>,
 }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -474,7 +474,10 @@ impl<U, E> FrameworkOptions<U, E> {
         };
 
         self.id_count += 1;
-        let command_id = CommandId { id: self.id_count, name };
+        let command_id = CommandId {
+            id: self.id_count,
+            name,
+        };
 
         if let Some(mut prefix_command) = builder.prefix_command {
             self.prefix_options.commands.push({

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -178,19 +178,12 @@ impl<U, E> Context<'_, U, E> {
         }
     }
 
-    /// Retunrs the name of the command.
-    ///
-    /// Can return None if the prefix context command field is None.
-    pub fn command_name(&self) -> Option<&'static str> {
-        match self {
-            Self::Prefix(ctx) => Some(ctx.command?.name),
-            Self::Application(ctx) => {
-                match ctx.command {
-                    crate::ApplicationCommand::Slash(cmd) => Some(cmd.name),
-                    crate::ApplicationCommand::ContextMenu(cmd) => Some(cmd.name),
-                }
-            }
-        }
+    /// Returns a reference to the command.
+    pub fn command(&self) -> Option<crate::CommandRef<'_, U, E>> {
+        Some(match self {
+            Self::Prefix(x) => crate::CommandRef::Prefix(x.command?),
+            Self::Application(x) => crate::CommandRef::Application(x.command),
+        })
     }
 }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -391,7 +391,7 @@ impl<U, E> CommandBuilder<U, E> {
                     crate::SlashCommandMeta::CommandGroup { subcommands, .. } => {
                         subcommands.push({
                             if let crate::SlashCommandMeta::Command(ref mut cmd) = subcommand {
-                                cmd.id = command_id.clone();
+                                cmd.id = command_id;
                             }
 
                             subcommand
@@ -403,7 +403,7 @@ impl<U, E> CommandBuilder<U, E> {
                             description: cmd.description,
                             subcommands: {
                                 if let crate::SlashCommandMeta::Command(ref mut cmd) = subcommand {
-                                    cmd.id = command_id.clone();
+                                    cmd.id = command_id;
                                 }
 
                                 vec![subcommand]
@@ -445,7 +445,7 @@ pub struct FrameworkOptions<U, E> {
     pub prefix_options: crate::PrefixFrameworkOptions<U, E>,
     /// User IDs which are allowed to use owners_only commands
     pub owners: std::collections::HashSet<serenity::UserId>,
-    /// The IDs of the registered commands. This has individual commands, and will not have 
+    /// The IDs of the registered commands. This has individual commands, and will not have
     /// individual variants if they can be executed multiple ways.
     pub command_ids: Vec<CommandId>,
 }
@@ -536,15 +536,15 @@ impl<U, E> FrameworkOptions<U, E> {
                         cmd.id = command_id.clone();
                     }
 
-                    match &slash_command {
-                        crate::SlashCommandMeta::CommandGroup { ref subcommands, .. } => {
-                            for cmd in subcommands {
-                                if let crate::SlashCommandMeta::Command(cmd) = cmd {
-                                    self.command_ids.push(cmd.id.clone());
-                                }
+                    if let crate::SlashCommandMeta::CommandGroup {
+                        ref subcommands, ..
+                    } = &slash_command
+                    {
+                        for cmd in subcommands {
+                            if let crate::SlashCommandMeta::Command(cmd) = cmd {
+                                self.command_ids.push(cmd.id.clone());
                             }
                         }
-                        _ => ()
                     }
 
                     slash_command

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -26,7 +26,7 @@ impl<'a, U, E> From<crate::PrefixContext<'a, U, E>> for Context<'a, U, E> {
     }
 }
 impl<'a, U, E> Context<'a, U, E> {
-    /// Delegates to [`ApplicationContext::defer_response`].
+    /// Delegates to [`crate::ApplicationContext::defer_response`].
     ///
     /// This will make the response public; to make it ephemeral, use [`Self::defer_ephemeral()`].
     pub async fn defer(self) -> Result<(), serenity::Error> {
@@ -36,7 +36,7 @@ impl<'a, U, E> Context<'a, U, E> {
         Ok(())
     }
 
-    /// Delegates to [`ApplicationContext::defer_response`].
+    /// Delegates to [`crate::ApplicationContext::defer_response`].
     ///
     /// This will make the response ephemeral; to make it public, use [`Self::defer()`].
     pub async fn defer_ephemeral(self) -> Result<(), serenity::Error> {
@@ -46,7 +46,7 @@ impl<'a, U, E> Context<'a, U, E> {
         Ok(())
     }
 
-    /// If this is an application command, it delegates to [`ApplicationContext::defer_response`].
+    /// If this is an application command, it delegates to [`crate::ApplicationContext::defer_response`].
     ///
     /// If this is a prefix command, a typing broadcast is started until the return value is
     /// dropped.

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -216,9 +216,9 @@ impl<U, E> CommandRef<'_, U, E> {
     }
 
     /// Yield the ID of the command.
-    pub fn id(self) -> CommandId {
+    pub fn id(&self) -> &CommandId {
         match self {
-            Self::Prefix(x) => x.id.clone(),
+            Self::Prefix(x) => &x.id,
             Self::Application(x) => x.id(),
         }
     }


### PR DESCRIPTION
https://5124.16-b.it/ss/23:53:39_15-10-2021.png
Makes a command with different names (like context and normal command names) share the same ID, this can be used to determinate a specific command being run.