### PR TITLE
updated docs & removed deprecated method from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,14 @@ pub async fn age(
 #[tokio::main]
 async fn main() {
     poise::Framework::build()
-        .prefix("~")
         .token(std::env::var("DISCORD_BOT_TOKEN").unwrap())
         .user_data_setup(move |_ctx, _ready, _framework| Box::pin(async move { Ok(()) }))
         .options(poise::FrameworkOptions {
             // configure framework here
+            prefix_options: PrefixFrameworkOptions {
+                prefix: Some("~".into()),
+                ..Default::default()
+            },
             ..Default::default()
         })
         .command(age(), |f| f)

--- a/src/framework/builder.rs
+++ b/src/framework/builder.rs
@@ -5,7 +5,6 @@ use crate::BoxFuture;
 ///
 /// If one of the following required values is missing, the builder will panic on start:
 /// - [`Self::token`]
-/// - [`Self::prefix`]
 /// - [`Self::user_data_setup`]
 /// - [`Self::options`]
 ///


### PR DESCRIPTION
The `prefix` method on `FrameworkBuilder` had been deprecated in favor of its cousin in `FrameworkOptions`. This PR brings this change to the example featuring in the README.
In the same vain the PR also updates the docs for `FrameworkBuilder`.