### PR TITLE
Added `post_command` option to the framework.

### DIFF
--- a/src/framework/prefix.rs
+++ b/src/framework/prefix.rs
@@ -245,7 +245,7 @@ where
     (this.options.pre_command)(crate::Context::Prefix(ctx)).await;
 
     // Execute command
-    (command.action)(ctx, args).await.map_err(|e| {
+    let res = (command.action)(ctx, args).await.map_err(|e| {
         Some((
             e,
             crate::PrefixCommandErrorContext {
@@ -254,5 +254,9 @@ where
                 while_checking: false,
             },
         ))
-    })
+    });
+
+    (this.options.post_command)(crate::Context::Prefix(ctx)).await;
+
+    res
 }

--- a/src/framework/slash.rs
+++ b/src/framework/slash.rs
@@ -216,6 +216,8 @@ pub async fn dispatch_interaction<'a, U, E>(
         },
     };
 
+    (framework.options.post_command)(crate::Context::Application(ctx)).await;
+
     action_result.map_err(|e| {
         Some((
             e,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -375,6 +375,8 @@ pub struct FrameworkOptions<U, E> {
     pub on_error: fn(E, ErrorContext<'_, U, E>) -> BoxFuture<'_, ()>,
     /// Called before every command
     pub pre_command: fn(Context<'_, U, E>) -> BoxFuture<'_, ()>,
+    /// Called after every command
+    pub post_command: fn(Context<'_, U, E>) -> BoxFuture<'_, ()>,
     /// Provide a callback to be invoked before every command. The command will only be executed
     /// if the callback returns true.
     ///
@@ -506,6 +508,7 @@ impl<U: Send + Sync, E: std::fmt::Display + Send> Default for FrameworkOptions<U
             },
             listener: |_, _, _, _| Box::pin(async { Ok(()) }),
             pre_command: |_| Box::pin(async {}),
+            post_command: |_| Box::pin(async {}),
             command_check: None,
             allowed_mentions: Some({
                 let mut f = serenity::CreateAllowedMentions::default();


### PR DESCRIPTION
`pre_command` already exists and serenity's framework also has a similar `after` "option" to their framework. Adding the same to poise seemed natural.