### PR TITLE
Fix lifetimes for some `send` functions

### DIFF
--- a/src/prefix/track_edits.rs
+++ b/src/prefix/track_edits.rs
@@ -138,9 +138,9 @@ impl EditTracker {
 }
 
 /// Prefix-specific reply function. For more details, see [`crate::send_reply`].
-pub async fn send_prefix_reply<U, E>(
+pub async fn send_prefix_reply<'a, U, E>(
     ctx: crate::prefix::PrefixContext<'_, U, E>,
-    builder: impl for<'a, 'b> FnOnce(&'a mut crate::CreateReply<'b>) -> &'a mut crate::CreateReply<'b>,
+    builder: impl for<'b> FnOnce(&'b mut crate::CreateReply<'a>) -> &'b mut crate::CreateReply<'a>,
 ) -> Result<serenity::Message, serenity::Error> {
     let mut reply = crate::CreateReply::default();
     builder(&mut reply);

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -121,9 +121,9 @@ impl ReplyHandle<'_> {
 /// ).await?;
 /// # Ok(()) }
 /// ```
-pub async fn send_reply<U, E>(
+pub async fn send_reply<'a, U, E>(
     ctx: crate::Context<'_, U, E>,
-    builder: impl for<'a, 'b> FnOnce(&'a mut CreateReply<'b>) -> &'a mut CreateReply<'b>,
+    builder: impl for<'b> FnOnce(&'b mut CreateReply<'a>) -> &'b mut CreateReply<'a>,
 ) -> Result<Option<ReplyHandle<'_>>, serenity::Error> {
     Ok(match ctx {
         crate::Context::Prefix(ctx) => Some(ReplyHandle::Prefix(

--- a/src/slash/mod.rs
+++ b/src/slash/mod.rs
@@ -87,9 +87,9 @@ fn send_as_followup_response<'a>(
 /// [followup](serenity::ApplicationCommandInteraction::create_followup_message) is sent.
 ///
 /// No-op if autocomplete context
-pub async fn send_application_reply<U, E>(
+pub async fn send_application_reply<'a, U, E>(
     ctx: ApplicationContext<'_, U, E>,
-    builder: impl for<'a, 'b> FnOnce(&'a mut crate::CreateReply<'b>) -> &'a mut crate::CreateReply<'b>,
+    builder: impl for<'b> FnOnce(&'b mut crate::CreateReply<'a>) -> &'b mut crate::CreateReply<'a>,
 ) -> Result<(), serenity::Error> {
     let interaction = match ctx.interaction {
         crate::ApplicationCommandOrAutocompleteInteraction::ApplicationCommand(x) => x,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -70,11 +70,9 @@ impl<'a, U, E> Context<'a, U, E> {
     }
 
     /// Shorthand of [`crate::send_reply`]
-    pub async fn send(
+    pub async fn send<'b>(
         self,
-        builder: impl for<'b, 'c> FnOnce(
-            &'b mut crate::CreateReply<'c>,
-        ) -> &'b mut crate::CreateReply<'c>,
+        builder: impl for<'c> FnOnce(&'c mut crate::CreateReply<'b>) -> &'c mut crate::CreateReply<'b>,
     ) -> Result<Option<crate::ReplyHandle<'a>>, serenity::Error> {
         crate::send_reply(self, builder).await
     }


### PR DESCRIPTION
<!-- please base the PR on the develop branch if possible 😇 -->

Currently, it is not possible to use `CreateReply::attachment` without `'static` `File`s. This is because of an error in the signature of `Context::send` - one of the the `builder` lifetimes should be associated with the `send` function instead of the builder. The same is true for `send_reply`, `send_prefix_reply`, and `send_application_reply` functions.

This PR fixes that by moving the lifetime to the correct position.
