### PR TITLE
Fixed matching subcommands with the same name

### DIFF
--- a/src/framework/dispatch/slash.rs
+++ b/src/framework/dispatch/slash.rs
@@ -26,7 +26,7 @@ fn find_matching_application_command<'a, 'b, U, E>(
             }
         }
         // TODO: improve this monstrosity
-        crate::ApplicationCommandTree::Slash(cmd) => match cmd {
+        crate::ApplicationCommandTree::Slash(cmd_meta) => match cmd_meta {
             crate::SlashCommandMeta::Command(cmd) => {
                 if cmd.name == interaction.name
                     && interaction.kind == serenity::ApplicationCommandType::ChatInput
@@ -43,6 +43,9 @@ fn find_matching_application_command<'a, 'b, U, E>(
                 description: _,
                 id: _,
             } => {
+                if cmd_meta.name() != interaction.name {
+                    return None;
+                }
                 let interaction = match interaction.options.iter().find(|option| {
                     option.kind == serenity::ApplicationCommandOptionType::SubCommand
                         || option.kind == serenity::ApplicationCommandOptionType::SubCommandGroup


### PR DESCRIPTION
Hi,
I've had a problem with two slash commands `/world info` and `/plot info`. Both `info`s are subcommands. I fixed it by comparing interaction name with slash command meta name
