### PR TITLE
Ensure global checks are always ran

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes",
  "fnv",
@@ -478,15 +478,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -866,18 +866,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "serenity"
 version = "0.10.10"
-source = "git+https://github.com/serenity-rs/serenity?branch=next#dc628147d2d3bac3433d895b6e5e009a3551553a"
+source = "git+https://github.com/serenity-rs/serenity?branch=next#5fa87332405c68d017dcfa93b15b78ca598fba5a"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -961,9 +961,9 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -1029,9 +1029,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
  "bytes",
  "libc",

--- a/src/framework/dispatch/common.rs
+++ b/src/framework/dispatch/common.rs
@@ -104,19 +104,20 @@ pub async fn check_permissions_and_cooldown<'a, U, E>(
 
     // Only continue if command checks returns true. First perform global checks, then command
     // checks (if necessary)
-    for check in [ctx.framework().options().command_check, cmd.check] {
-        if let Some(check) = check {
-            match check(ctx).await {
-                Ok(true) => {}
-                Ok(false) => {
-                    return Err(crate::FrameworkError::CommandCheckFailed { ctx, error: None })
-                }
-                Err(error) => {
-                    return Err(crate::FrameworkError::CommandCheckFailed {
-                        error: Some(error),
-                        ctx,
-                    })
-                }
+    for check in [ctx.framework().options().command_check, cmd.check]
+        .iter()
+        .flatten()
+    {
+        match check(ctx).await {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err(crate::FrameworkError::CommandCheckFailed { ctx, error: None })
+            }
+            Err(error) => {
+                return Err(crate::FrameworkError::CommandCheckFailed {
+                    error: Some(error),
+                    ctx,
+                })
             }
         }
     }

--- a/src/framework/dispatch/common.rs
+++ b/src/framework/dispatch/common.rs
@@ -104,32 +104,19 @@ pub async fn check_permissions_and_cooldown<'a, U, E>(
 
     // Only continue if command checks returns true. First perform global checks, then command
     // checks (if necessary)
-    if let Some(check) = ctx.framework().options().command_check {
-        match check(ctx).await {
-            Ok(true) => {}
-            Ok(false) => {
-                return Err(crate::FrameworkError::CommandCheckFailed { ctx, error: None })
-            }
-            Err(error) => {
-                return Err(crate::FrameworkError::CommandCheckFailed {
-                    error: Some(error),
-                    ctx,
-                })
-            }
-        }
-    }
-
-    if let Some(check) = cmd.check {
-        match check(ctx).await {
-            Ok(true) => {}
-            Ok(false) => {
-                return Err(crate::FrameworkError::CommandCheckFailed { ctx, error: None })
-            }
-            Err(error) => {
-                return Err(crate::FrameworkError::CommandCheckFailed {
-                    error: Some(error),
-                    ctx,
-                })
+    for check in [ctx.framework().options().command_check, cmd.check] {
+        if let Some(check) = check {
+            match check(ctx).await {
+                Ok(true) => {}
+                Ok(false) => {
+                    return Err(crate::FrameworkError::CommandCheckFailed { ctx, error: None })
+                }
+                Err(error) => {
+                    return Err(crate::FrameworkError::CommandCheckFailed {
+                        error: Some(error),
+                        ctx,
+                    })
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes issue where if a command specified its own checks, global checks (those registered on the framework) would not be ran