### PR TITLE
Implement allowed_mentions and reference_message per message.

### DIFF
--- a/src/prefix/track_edits.rs
+++ b/src/prefix/track_edits.rs
@@ -163,6 +163,8 @@ pub async fn send_prefix_reply<'a, U, E>(
         attachments,
         components,
         ephemeral: _,
+        allowed_mentions,
+        reference_message,
     } = reply;
 
     let lock_edit_tracker = || {
@@ -200,7 +202,7 @@ pub async fn send_prefix_reply<'a, U, E>(
                     f.attachment(attachment);
                 }
 
-                // When components is None, this will still be run to reset the message components
+                // When components is None, this will still be run to reset the components.
                 f.components(|f| {
                     if let Some(components) = components {
                         *f = components;
@@ -230,7 +232,12 @@ pub async fn send_prefix_reply<'a, U, E>(
                     m.content(content);
                 }
                 m.set_embeds(embeds);
-                if let Some(allowed_mentions) = &ctx.framework.options().allowed_mentions {
+                if let Some(allowed_mentions) = allowed_mentions {
+                    m.allowed_mentions(|c| {
+                        c.0 = allowed_mentions.0;
+                        c
+                    });
+                } else if let Some(allowed_mentions) = &ctx.framework.options().allowed_mentions {
                     m.allowed_mentions(|m| {
                         *m = allowed_mentions.clone();
                         m
@@ -241,6 +248,9 @@ pub async fn send_prefix_reply<'a, U, E>(
                         c.0 = components.0;
                         c
                     });
+                }
+                if let Some(reference_message) = reference_message {
+                    m.reference_message(reference_message);
                 }
 
                 for attachment in attachments {

--- a/src/prefix/track_edits.rs
+++ b/src/prefix/track_edits.rs
@@ -232,14 +232,11 @@ pub async fn send_prefix_reply<'a, U, E>(
                     m.content(content);
                 }
                 m.set_embeds(embeds);
-                if let Some(allowed_mentions) = allowed_mentions {
-                    m.allowed_mentions(|c| {
-                        c.0 = allowed_mentions.0;
-                        c
-                    });
-                } else if let Some(allowed_mentions) = &ctx.framework.options().allowed_mentions {
+                if let Some(allowed_mentions) =
+                    allowed_mentions.or_else(|| ctx.framework.options().allowed_mentions.clone())
+                {
                     m.allowed_mentions(|m| {
-                        *m = allowed_mentions.clone();
+                        *m = allowed_mentions;
                         m
                     });
                 }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -80,7 +80,7 @@ impl<'a> CreateReply<'a> {
 
     /// Set the allowed mentions for the message.
     ///
-    /// See the [serenity documentation](https://serenity-rs.github.io/serenity/next/serenity/builder/struct.CreateAllowedMentions.html) for more information.
+    /// See [`serenity::CreateAllowedMentions`] for more information.
     pub fn allowed_mentions(
         &mut self,
         f: impl FnOnce(&mut serenity::CreateAllowedMentions) -> &mut serenity::CreateAllowedMentions,

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -8,16 +8,20 @@ use crate::serenity_prelude as serenity;
 /// Message builder that abstracts over prefix and application command responses
 #[derive(Default)]
 pub struct CreateReply<'a> {
-    /// Message content
+    /// Message content.
     pub content: Option<String>,
-    /// Embeds, if present
+    /// Embeds, if present.
     pub embeds: Vec<serenity::CreateEmbed>,
-    /// Message attachments
+    /// Message attachments.
     pub attachments: Vec<serenity::AttachmentType<'a>>,
     /// Whether the message is ephemeral (only has an effect in application commands)
     pub ephemeral: bool,
-    /// Message components, that is, buttons
+    /// Message components, that is, buttons and select menus.
     pub components: Option<serenity::CreateComponents>,
+    /// The allowed mentions for the message.
+    pub allowed_mentions: Option<serenity::CreateAllowedMentions>,
+    /// The reference message this message is a reply to.
+    pub reference_message: Option<serenity::MessageReference>,
 }
 
 impl<'a> CreateReply<'a> {
@@ -40,7 +44,7 @@ impl<'a> CreateReply<'a> {
         self
     }
 
-    /// Set components (buttons) for this message.
+    /// Set components (buttons and select menus) for this message.
     ///
     /// Any previously set components will be overwritten.
     pub fn components(
@@ -71,6 +75,28 @@ impl<'a> CreateReply<'a> {
     /// ephemeral.
     pub fn ephemeral(&mut self, ephemeral: bool) -> &mut Self {
         self.ephemeral = ephemeral;
+        self
+    }
+
+    /// Set the allowed mentions for the message.
+    ///
+    /// See the [serenity documentation](https://serenity-rs.github.io/serenity/next/serenity/builder/struct.CreateAllowedMentions.html) for more information.
+    pub fn allowed_mentions(
+        &mut self,
+        f: impl FnOnce(&mut serenity::CreateAllowedMentions) -> &mut serenity::CreateAllowedMentions,
+    ) -> &mut Self {
+        let mut allowed_mentions = serenity::CreateAllowedMentions::default();
+        f(&mut allowed_mentions);
+        self.allowed_mentions = Some(allowed_mentions);
+        self
+    }
+
+    /// Set the reference message this message is a reply to.
+    pub fn reference_message(
+        &mut self,
+        reference: impl Into<serenity::MessageReference>,
+    ) -> &mut Self {
+        self.reference_message = Some(reference.into());
         self
     }
 }

--- a/src/slash/mod.rs
+++ b/src/slash/mod.rs
@@ -15,7 +15,6 @@ fn send_as_initial_response(
     allowed_mentions: Option<&serenity::CreateAllowedMentions>,
     f: &mut serenity::CreateInteractionResponseData,
 ) {
-
     let crate::CreateReply {
         content,
         embeds,
@@ -26,7 +25,7 @@ fn send_as_initial_response(
         reference_message: _, // can't reply to a message in interactions
     } = {
         if data.allowed_mentions.is_none() {
-            data.allowed_mentions = allowed_mentions.map(|i| i.clone());
+            data.allowed_mentions = allowed_mentions.cloned();
         }
 
         data
@@ -70,7 +69,7 @@ fn send_as_followup_response<'a>(
         reference_message: _,
     } = {
         if data.allowed_mentions.is_none() {
-            data.allowed_mentions = allowed_mentions.map(|i| i.clone());
+            data.allowed_mentions = allowed_mentions.cloned();
         }
 
         data
@@ -115,7 +114,7 @@ fn send_as_edit<'a>(
         reference_message: _,
     } = {
         if data.allowed_mentions.is_none() {
-            data.allowed_mentions = allowed_mentions.map(|i| i.clone());
+            data.allowed_mentions = allowed_mentions.cloned();
         }
 
         data

--- a/src/slash/mod.rs
+++ b/src/slash/mod.rs
@@ -11,17 +11,26 @@ use crate::serenity_prelude as serenity;
 /// Sends the message, specified via [`crate::CreateReply`], to the interaction initial response
 /// endpoint
 fn send_as_initial_response(
-    data: crate::CreateReply<'_>,
+    mut data: crate::CreateReply<'_>,
     allowed_mentions: Option<&serenity::CreateAllowedMentions>,
     f: &mut serenity::CreateInteractionResponseData,
 ) {
+
     let crate::CreateReply {
         content,
         embeds,
         attachments: _, // serenity doesn't support attachments in initial response yet
         components,
         ephemeral,
-    } = data;
+        allowed_mentions,
+        reference_message: _, // can't reply to a message in interactions
+    } = {
+        if data.allowed_mentions.is_none() {
+            data.allowed_mentions = allowed_mentions.map(|i| i.clone());
+        }
+
+        data
+    };
 
     if let Some(content) = content {
         f.content(content);
@@ -47,7 +56,7 @@ fn send_as_initial_response(
 /// Sends the message, specified via [`crate::CreateReply`], to the interaction followup response
 /// endpoint
 fn send_as_followup_response<'a>(
-    data: crate::CreateReply<'a>,
+    mut data: crate::CreateReply<'a>,
     allowed_mentions: Option<&serenity::CreateAllowedMentions>,
     f: &mut serenity::CreateInteractionResponseFollowup<'a>,
 ) {
@@ -57,7 +66,15 @@ fn send_as_followup_response<'a>(
         attachments,
         components,
         ephemeral,
-    } = data;
+        allowed_mentions,
+        reference_message: _,
+    } = {
+        if data.allowed_mentions.is_none() {
+            data.allowed_mentions = allowed_mentions.map(|i| i.clone());
+        }
+
+        data
+    };
 
     if let Some(content) = content {
         f.content(content);
@@ -84,7 +101,7 @@ fn send_as_followup_response<'a>(
 /// Sends the message, specified via [`crate::CreateReply`], to the interaction initial response
 /// edit endpoint
 fn send_as_edit<'a>(
-    data: crate::CreateReply<'a>,
+    mut data: crate::CreateReply<'a>,
     allowed_mentions: Option<&serenity::CreateAllowedMentions>,
     f: &mut serenity::EditInteractionResponse,
 ) {
@@ -94,7 +111,15 @@ fn send_as_edit<'a>(
         attachments: _, // no support for attachment edits in serenity yet
         components,
         ephemeral: _, // can't edit ephemerality in retrospect
-    } = data;
+        allowed_mentions,
+        reference_message: _,
+    } = {
+        if data.allowed_mentions.is_none() {
+            data.allowed_mentions = allowed_mentions.map(|i| i.clone());
+        }
+
+        data
+    };
 
     if let Some(content) = content {
         f.content(content);

--- a/src/slash/mod.rs
+++ b/src/slash/mod.rs
@@ -11,8 +11,7 @@ use crate::serenity_prelude as serenity;
 /// Sends the message, specified via [`crate::CreateReply`], to the interaction initial response
 /// endpoint
 fn send_as_initial_response(
-    mut data: crate::CreateReply<'_>,
-    allowed_mentions: Option<&serenity::CreateAllowedMentions>,
+    data: crate::CreateReply<'_>,
     f: &mut serenity::CreateInteractionResponseData,
 ) {
     let crate::CreateReply {
@@ -23,13 +22,7 @@ fn send_as_initial_response(
         ephemeral,
         allowed_mentions,
         reference_message: _, // can't reply to a message in interactions
-    } = {
-        if data.allowed_mentions.is_none() {
-            data.allowed_mentions = allowed_mentions.cloned();
-        }
-
-        data
-    };
+    } = data;
 
     if let Some(content) = content {
         f.content(content);
@@ -55,8 +48,7 @@ fn send_as_initial_response(
 /// Sends the message, specified via [`crate::CreateReply`], to the interaction followup response
 /// endpoint
 fn send_as_followup_response<'a>(
-    mut data: crate::CreateReply<'a>,
-    allowed_mentions: Option<&serenity::CreateAllowedMentions>,
+    data: crate::CreateReply<'a>,
     f: &mut serenity::CreateInteractionResponseFollowup<'a>,
 ) {
     let crate::CreateReply {
@@ -67,13 +59,7 @@ fn send_as_followup_response<'a>(
         ephemeral,
         allowed_mentions,
         reference_message: _,
-    } = {
-        if data.allowed_mentions.is_none() {
-            data.allowed_mentions = allowed_mentions.cloned();
-        }
-
-        data
-    };
+    } = data;
 
     if let Some(content) = content {
         f.content(content);
@@ -99,11 +85,7 @@ fn send_as_followup_response<'a>(
 
 /// Sends the message, specified via [`crate::CreateReply`], to the interaction initial response
 /// edit endpoint
-fn send_as_edit<'a>(
-    mut data: crate::CreateReply<'a>,
-    allowed_mentions: Option<&serenity::CreateAllowedMentions>,
-    f: &mut serenity::EditInteractionResponse,
-) {
+fn send_as_edit(data: crate::CreateReply<'_>, f: &mut serenity::EditInteractionResponse) {
     let crate::CreateReply {
         content,
         embeds,
@@ -112,13 +94,7 @@ fn send_as_edit<'a>(
         ephemeral: _, // can't edit ephemerality in retrospect
         allowed_mentions,
         reference_message: _,
-    } = {
-        if data.allowed_mentions.is_none() {
-            data.allowed_mentions = allowed_mentions.cloned();
-        }
-
-        data
-    };
+    } = data;
 
     if let Some(content) = content {
         f.content(content);
@@ -155,6 +131,7 @@ pub async fn send_application_reply<'a, U, E>(
 
     let mut data = crate::CreateReply {
         ephemeral: ctx.command.ephemeral,
+        allowed_mentions: ctx.framework.options().allowed_mentions.clone(),
         ..Default::default()
     };
     builder(&mut data);
@@ -163,19 +140,18 @@ pub async fn send_application_reply<'a, U, E>(
         .has_sent_initial_response
         .load(std::sync::atomic::Ordering::SeqCst);
 
-    let allowed_mentions = ctx.framework.options().allowed_mentions.as_ref();
     if has_sent_initial_response {
         if ctx.command.reuse_response {
             interaction
                 .edit_original_interaction_response(ctx.discord, |f| {
-                    send_as_edit(data, allowed_mentions, f);
+                    send_as_edit(data, f);
                     f
                 })
                 .await?;
         } else {
             interaction
                 .create_followup_message(ctx.discord, |f| {
-                    send_as_followup_response(data, allowed_mentions, f);
+                    send_as_followup_response(data, f);
                     f
                 })
                 .await?;
@@ -185,7 +161,7 @@ pub async fn send_application_reply<'a, U, E>(
             .create_interaction_response(ctx.discord, |r| {
                 r.kind(serenity::InteractionResponseType::ChannelMessageWithSource)
                     .interaction_response_data(|f| {
-                        send_as_initial_response(data, allowed_mentions, f);
+                        send_as_initial_response(data, f);
                         f
                     })
             })

--- a/src/structs/framework_options.rs
+++ b/src/structs/framework_options.rs
@@ -18,6 +18,8 @@ pub struct FrameworkOptions<U, E> {
     /// If individual commands add their own check, both callbacks are run and must return true.
     pub command_check: Option<fn(crate::Context<'_, U, E>) -> BoxFuture<'_, Result<bool, E>>>,
     /// Default set of allowed mentions to use for all responses
+    ///
+    /// By default, user pings are allowed and role pings and everyone pings are filtered
     pub allowed_mentions: Option<serenity::CreateAllowedMentions>,
     /// Called on every Discord event. Can be used to react to non-command events, like messages
     /// deletions or guild updates.


### PR DESCRIPTION
Implements `allowed_mentions` and `reference_message` for sending and editing messages. `allowed_mentions` will override the global one if present, and `reference_message` will only work on normal message sends.

	modified:   src/prefix/track_edits.rs
	modified:   src/reply.rs
	modified:   src/slash/mod.rs
