### PR TITLE
change identifying name

### DIFF
--- a/macros/src/command/mod.rs
+++ b/macros/src/command/mod.rs
@@ -241,11 +241,7 @@ fn generate_command(mut inv: Invocation) -> Result<proc_macro2::TokenStream, dar
         None => None,
     });
 
-    let identifying_name = inv
-        .args
-        .identifying_name
-        .as_ref()
-        .unwrap_or(&inv.command_name);
+    let identifying_name = inv.function.sig.ident.to_string();
     let command_name = &inv.command_name;
     let context_menu_name = wrap_option(inv.args.context_menu_command.as_ref());
 


### PR DESCRIPTION
Proposed change that sets the identifying name to default to the function identifier rather than the command name. This change helps keep identifying names unique even with subcommands.

An alternative could be to create the identifying name from the full qualified command name, but this was a quicker potential solution.

Change could be breaking.