### PR TITLE
Add ctx and framework to listener error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +695,7 @@ name = "poise"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "derivative",
  "futures",
  "futures-core",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ poise_macros = { path = "macros" }
 async-trait = { version = "0.1.48", default-features = false } # various traits
 regex = { version = "1.5.4", default-features = false, features = ["std"] } # prefix
 log = { version = "0.4.14", default-features = false } # warning about weird state
+derivative = "2.2.0"
 
 [dependencies.serenity]
 default-features = false

--- a/examples/serenity_example_port/main.rs
+++ b/examples/serenity_example_port/main.rs
@@ -166,7 +166,12 @@ async fn on_error(error: poise::FrameworkError<'_, Data, Error>) {
                 error
             );
         }
-        poise::FrameworkError::Listener { error, event, ctx: _, framework: _ } => {
+        poise::FrameworkError::Listener {
+            error,
+            event,
+            ctx: _,
+            framework: _,
+        } => {
             println!(
                 "Listener returned error during {:?} event: {:?}",
                 event.name(),

--- a/examples/serenity_example_port/main.rs
+++ b/examples/serenity_example_port/main.rs
@@ -166,7 +166,7 @@ async fn on_error(error: poise::FrameworkError<'_, Data, Error>) {
                 error
             );
         }
-        poise::FrameworkError::Listener { error, event } => {
+        poise::FrameworkError::Listener { error, event, ctx: _, framework: _ } => {
             println!(
                 "Listener returned error during {:?} event: {:?}",
                 event.name(),

--- a/examples/serenity_example_port/main.rs
+++ b/examples/serenity_example_port/main.rs
@@ -166,12 +166,7 @@ async fn on_error(error: poise::FrameworkError<'_, Data, Error>) {
                 error
             );
         }
-        poise::FrameworkError::Listener {
-            error,
-            event,
-            ctx: _,
-            framework: _,
-        } => {
+        poise::FrameworkError::Listener { error, event, .. } => {
             println!(
                 "Listener returned error during {:?} event: {:?}",
                 event.name(),

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -26,7 +26,7 @@ pub async fn on_error<U, E: std::fmt::Display + std::fmt::Debug>(
 ) -> Result<(), serenity::Error> {
     match error {
         crate::FrameworkError::Setup { error } => println!("Error in user data setup: {}", error),
-        crate::FrameworkError::Listener { error, event } => println!(
+        crate::FrameworkError::Listener { error, event, ctx: _, framework: _ } => println!(
             "User event listener encountered an error on {} event: {}",
             event.name(),
             error

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -26,12 +26,7 @@ pub async fn on_error<U, E: std::fmt::Display + std::fmt::Debug>(
 ) -> Result<(), serenity::Error> {
     match error {
         crate::FrameworkError::Setup { error } => println!("Error in user data setup: {}", error),
-        crate::FrameworkError::Listener {
-            error,
-            event,
-            ctx: _,
-            framework: _,
-        } => println!(
+        crate::FrameworkError::Listener { error, event, .. } => println!(
             "User event listener encountered an error on {} event: {}",
             event.name(),
             error

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -26,7 +26,12 @@ pub async fn on_error<U, E: std::fmt::Display + std::fmt::Debug>(
 ) -> Result<(), serenity::Error> {
     match error {
         crate::FrameworkError::Setup { error } => println!("Error in user data setup: {}", error),
-        crate::FrameworkError::Listener { error, event, ctx: _, framework: _ } => println!(
+        crate::FrameworkError::Listener {
+            error,
+            event,
+            ctx: _,
+            framework: _,
+        } => println!(
             "User event listener encountered an error on {} event: {}",
             event.name(),
             error

--- a/src/framework/dispatch/mod.rs
+++ b/src/framework/dispatch/mod.rs
@@ -115,7 +115,7 @@ pub async fn dispatch_event<U, E>(
     if let Err(error) =
         (framework.options.listener)(&ctx, event, framework, framework.user_data().await).await
     {
-        let error = crate::FrameworkError::Listener { error, event };
+        let error = crate::FrameworkError::Listener { ctx, error, event, framework };
         (framework.options.on_error)(error).await;
     }
 }

--- a/src/framework/dispatch/mod.rs
+++ b/src/framework/dispatch/mod.rs
@@ -115,7 +115,12 @@ pub async fn dispatch_event<U, E>(
     if let Err(error) =
         (framework.options.listener)(&ctx, event, framework, framework.user_data().await).await
     {
-        let error = crate::FrameworkError::Listener { ctx, error, event, framework };
+        let error = crate::FrameworkError::Listener {
+            ctx,
+            error,
+            event,
+            framework,
+        };
         (framework.options.on_error)(error).await;
     }
 }

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -1,5 +1,7 @@
 //! Plain data structs that define the framework configuration.
 
+use derivative::Derivative;
+
 mod context;
 pub use context::*;
 
@@ -9,7 +11,7 @@ pub use framework_options::*;
 mod command;
 pub use command::*;
 
-use crate::serenity_prelude as serenity;
+use crate::{serenity_prelude as serenity, Framework};
 
 // needed for proc macro
 #[doc(hidden)]
@@ -26,7 +28,8 @@ impl<U, E> _GetGenerics for Context<'_, U, E> {
 /// have an `error` field with your error type `E` in it), or originating from within the framework.
 ///
 /// These errors are handled with the [`crate::FrameworkOptions::on_error`] callback
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub enum FrameworkError<'a, U, E> {
     /// User code threw an error in user data setup
     Setup {
@@ -37,8 +40,14 @@ pub enum FrameworkError<'a, U, E> {
     Listener {
         /// Error which was thrown in the listener code
         error: E,
+        /// The serenity Context passed to the event
+        #[derivative(Debug="ignore")]
+        ctx: serenity::Context,
         /// Which event was being processed when the error occurred
         event: &'a crate::Event<'a>,
+        /// The Framework passed to the event
+        #[derivative(Debug="ignore")]
+        framework: &'a Framework<U, E>,
     },
     /// Error occured during command execution
     Command {

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -1,7 +1,5 @@
 //! Plain data structs that define the framework configuration.
 
-use derivative::Derivative;
-
 mod context;
 pub use context::*;
 
@@ -11,7 +9,7 @@ pub use framework_options::*;
 mod command;
 pub use command::*;
 
-use crate::{serenity_prelude as serenity, Framework};
+use crate::serenity_prelude as serenity;
 
 // needed for proc macro
 #[doc(hidden)]
@@ -28,7 +26,7 @@ impl<U, E> _GetGenerics for Context<'_, U, E> {
 /// have an `error` field with your error type `E` in it), or originating from within the framework.
 ///
 /// These errors are handled with the [`crate::FrameworkOptions::on_error`] callback
-#[derive(Derivative)]
+#[derive(derivative::Derivative)]
 #[derivative(Debug)]
 pub enum FrameworkError<'a, U, E> {
     /// User code threw an error in user data setup
@@ -47,7 +45,7 @@ pub enum FrameworkError<'a, U, E> {
         event: &'a crate::Event<'a>,
         /// The Framework passed to the event
         #[derivative(Debug = "ignore")]
-        framework: &'a Framework<U, E>,
+        framework: &'a crate::Framework<U, E>,
     },
     /// Error occured during command execution
     Command {

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -41,12 +41,12 @@ pub enum FrameworkError<'a, U, E> {
         /// Error which was thrown in the listener code
         error: E,
         /// The serenity Context passed to the event
-        #[derivative(Debug="ignore")]
+        #[derivative(Debug = "ignore")]
         ctx: serenity::Context,
         /// Which event was being processed when the error occurred
         event: &'a crate::Event<'a>,
         /// The Framework passed to the event
-        #[derivative(Debug="ignore")]
+        #[derivative(Debug = "ignore")]
         framework: &'a Framework<U, E>,
     },
     /// Error occured during command execution


### PR DESCRIPTION
<!-- please base the PR on the develop branch if possible 😇 -->
`FrameworkError::Listener` gets a surprising lack of `serenity::Context` or `Framework`, let's fix that!