### PR TITLE
Add ignore_bots to PrefixFrameworkOptions

### DIFF
--- a/src/framework/dispatch/prefix.rs
+++ b/src/framework/dispatch/prefix.rs
@@ -178,7 +178,7 @@ where
 {
     // Check if we're allowed to invoke from bot messages
     if msg.author.bot && framework.options.prefix_options.ignore_bots {
-        return Err(None)
+        return Err(None);
     }
 
     // Strip prefix and whitespace between prefix and command

--- a/src/framework/dispatch/prefix.rs
+++ b/src/framework/dispatch/prefix.rs
@@ -176,6 +176,11 @@ pub async fn dispatch_message<'a, U, E>(
 where
     U: Send + Sync,
 {
+    // Check if we're allowed to invoke from bot messages
+    if msg.author.bot && framework.options.prefix_options.ignore_bots {
+        return Err(None)
+    }
+
     // Strip prefix and whitespace between prefix and command
     let (prefix, msg_content) = strip_prefix(framework, ctx, msg).await.ok_or(None)?;
     let msg_content = msg_content.trim_start();

--- a/src/framework/dispatch/prefix.rs
+++ b/src/framework/dispatch/prefix.rs
@@ -185,10 +185,6 @@ where
         return Err(None);
     }
 
-    // Strip prefix and whitespace between prefix and command
-    let (prefix, msg_content) = strip_prefix(framework, ctx, msg).await.ok_or(None)?;
-    let msg_content = msg_content.trim_start();
-
     // Check if we're allowed to execute our own messages
     if let Some(&bot_id) = framework.bot_id.get() {
         if bot_id == msg.author.id && !framework.options.prefix_options.execute_self_messages {
@@ -198,10 +194,9 @@ where
         log::warn!("bot_id not yet initialized");
     }
 
-    // Check if we're allowed to execute bot messages
-    if msg.author.bot && !framework.options.prefix_options.execute_bot_messages {
-        return Err(None);
-    }
+    // Strip prefix and whitespace between prefix and command
+    let (prefix, msg_content) = strip_prefix(framework, ctx, msg).await.ok_or(None)?;
+    let msg_content = msg_content.trim_start();
 
     let (command, invoked_command_name, args) = find_command(
         &framework.options.commands,

--- a/src/prefix/structs.rs
+++ b/src/prefix/structs.rs
@@ -134,12 +134,10 @@ pub struct PrefixFrameworkOptions<U, E> {
 
     /// Whether commands in messages emitted by this bot itself should be executed as well.
     pub execute_self_messages: bool,
-    /// Whether commands in messages emitted by bots in general should be executed as well.
-    pub execute_bot_messages: bool,
-    /// Whether command names should be compared case-insensitively.
-    pub case_insensitive_commands: bool,
     /// Whether to ignore messages from bots for command invoking. Default `true`
     pub ignore_bots: bool,
+    /// Whether command names should be compared case-insensitively.
+    pub case_insensitive_commands: bool,
     /* // TODO: implement
     /// Whether to invoke help command when someone sends a message with just a bot mention
     pub help_when_mentioned: bool,
@@ -163,9 +161,8 @@ impl<U: std::fmt::Debug, E: std::fmt::Debug> std::fmt::Debug for PrefixFramework
             execute_untracked_edits,
             ignore_edits_if_not_yet_responded,
             execute_self_messages,
-            execute_bot_messages,
-            case_insensitive_commands,
             ignore_bots,
+            case_insensitive_commands,
         } = self;
 
         f.debug_struct("PrefixFrameworkOptions")
@@ -184,9 +181,8 @@ impl<U: std::fmt::Debug, E: std::fmt::Debug> std::fmt::Debug for PrefixFramework
                 ignore_edits_if_not_yet_responded,
             )
             .field("execute_self_messages", execute_self_messages)
-            .field("execute_bot_messages", execute_bot_messages)
-            .field("case_insensitive_commands", case_insensitive_commands)
             .field("ignore_bots", ignore_bots)
+            .field("case_insensitive_commands", case_insensitive_commands)
             .finish()
     }
 }
@@ -203,9 +199,8 @@ impl<U, E> Default for PrefixFrameworkOptions<U, E> {
             execute_untracked_edits: true,
             ignore_edits_if_not_yet_responded: false,
             execute_self_messages: false,
-            execute_bot_messages: true,
-            case_insensitive_commands: true,
             ignore_bots: true,
+            case_insensitive_commands: true,
             // help_when_mentioned: true,
             // help_commmand: None,
             // command_specific_help_commmand: None,

--- a/src/prefix/structs.rs
+++ b/src/prefix/structs.rs
@@ -136,6 +136,8 @@ pub struct PrefixFrameworkOptions<U, E> {
     pub execute_self_messages: bool,
     /// Whether command names should be compared case-insensitively.
     pub case_insensitive_commands: bool,
+    /// Whether to ignore messages from bots for command invoking. Default `true`
+    pub ignore_bots: bool,
     /* // TODO: implement
     /// Whether to invoke help command when someone sends a message with just a bot mention
     pub help_when_mentioned: bool,
@@ -160,6 +162,7 @@ impl<U: std::fmt::Debug, E: std::fmt::Debug> std::fmt::Debug for PrefixFramework
             ignore_edits_if_not_yet_responded,
             execute_self_messages,
             case_insensitive_commands,
+            ignore_bots,
         } = self;
 
         f.debug_struct("PrefixFrameworkOptions")
@@ -179,6 +182,7 @@ impl<U: std::fmt::Debug, E: std::fmt::Debug> std::fmt::Debug for PrefixFramework
             )
             .field("execute_self_messages", execute_self_messages)
             .field("case_insensitive_commands", case_insensitive_commands)
+            .field("ignore_bots", ignore_bots)
             .finish()
     }
 }
@@ -196,6 +200,7 @@ impl<U, E> Default for PrefixFrameworkOptions<U, E> {
             ignore_edits_if_not_yet_responded: false,
             execute_self_messages: false,
             case_insensitive_commands: true,
+            ignore_bots: true,
             // help_when_mentioned: true,
             // help_commmand: None,
             // command_specific_help_commmand: None,


### PR DESCRIPTION
<!-- please base the PR on the develop branch if possible 😇 -->
99% of bots ignore other bots for command invokes so poise should reflect this norm, but old behavior can be re-enabled via an option on `PrefixFrameworkOptions` 