### PR TITLE
Minimize monomorphization-caused codegen bloat

### DIFF
--- a/src/prefix/track_edits.rs
+++ b/src/prefix/track_edits.rs
@@ -173,7 +173,7 @@ pub async fn send_prefix_reply<'a, U, E>(
     _send_prefix_reply(ctx, reply).await
 }
 
-// private function that isn't generic over the builder to minimize monomorphization-related codegen bloat
+/// private version of [`send_prefix_reply`] that isn't generic over the builder to minimize monomorphization-related codegen bloat
 async fn _send_prefix_reply<'a, U, E>(
     ctx: crate::prefix::PrefixContext<'_, U, E>,
     mut reply: crate::CreateReply<'a>,

--- a/src/prefix/track_edits.rs
+++ b/src/prefix/track_edits.rs
@@ -164,59 +164,66 @@ pub async fn send_prefix_reply<'a, U, E>(
     ctx: crate::prefix::PrefixContext<'_, U, E>,
     builder: impl for<'b> FnOnce(&'b mut crate::CreateReply<'a>) -> &'b mut crate::CreateReply<'a>,
 ) -> Result<Box<serenity::Message>, serenity::Error> {
+    // inner function that isn't generic over the builer to minimize monomorphization-related codegen bloat
+    async fn inner<'a, U, E>(
+        ctx: crate::prefix::PrefixContext<'_, U, E>,
+        mut reply: crate::CreateReply<'a>,
+    ) -> Result<Box<serenity::Message>, serenity::Error> {
+        if let Some(callback) = ctx.framework.options().reply_callback {
+            callback(ctx.into(), &mut reply);
+        }
+
+        // This must only return None when we _actually_ want to reuse the existing response! There are
+        // no checks later
+        let lock_edit_tracker = || {
+            if ctx.command.reuse_response {
+                if let Some(edit_tracker) = &ctx.framework.options().prefix_options.edit_tracker {
+                    return Some(edit_tracker.write().unwrap());
+                }
+            }
+            None
+        };
+
+        let existing_response = lock_edit_tracker()
+            .as_mut()
+            .and_then(|t| t.find_bot_response(ctx.msg.id))
+            .cloned();
+
+        Ok(Box::new(if let Some(mut response) = existing_response {
+            response
+                .edit(ctx.discord, |f| {
+                    reply.to_prefix_edit(f);
+                    f
+                })
+                .await?;
+
+            // If the entry still exists after the await, update it to the new contents
+            if let Some(mut edit_tracker) = lock_edit_tracker() {
+                edit_tracker.set_bot_response(ctx.msg, response.clone());
+            }
+
+            response
+        } else {
+            let new_response = ctx
+                .msg
+                .channel_id
+                .send_message(ctx.discord, |m| {
+                    reply.to_prefix(m);
+                    m
+                })
+                .await?;
+            if let Some(track_edits) = &mut lock_edit_tracker() {
+                track_edits.set_bot_response(ctx.msg, new_response.clone());
+            }
+
+            new_response
+        }))
+    }
     let mut reply = crate::CreateReply {
         ephemeral: ctx.command.ephemeral,
         allowed_mentions: ctx.framework.options().allowed_mentions.clone(),
         ..Default::default()
     };
     builder(&mut reply);
-    if let Some(callback) = ctx.framework.options().reply_callback {
-        callback(ctx.into(), &mut reply);
-    }
-
-    // This must only return None when we _actually_ want to reuse the existing response! There are
-    // no checks later
-    let lock_edit_tracker = || {
-        if ctx.command.reuse_response {
-            if let Some(edit_tracker) = &ctx.framework.options().prefix_options.edit_tracker {
-                return Some(edit_tracker.write().unwrap());
-            }
-        }
-        None
-    };
-
-    let existing_response = lock_edit_tracker()
-        .as_mut()
-        .and_then(|t| t.find_bot_response(ctx.msg.id))
-        .cloned();
-
-    Ok(Box::new(if let Some(mut response) = existing_response {
-        response
-            .edit(ctx.discord, |f| {
-                reply.to_prefix_edit(f);
-                f
-            })
-            .await?;
-
-        // If the entry still exists after the await, update it to the new contents
-        if let Some(mut edit_tracker) = lock_edit_tracker() {
-            edit_tracker.set_bot_response(ctx.msg, response.clone());
-        }
-
-        response
-    } else {
-        let new_response = ctx
-            .msg
-            .channel_id
-            .send_message(ctx.discord, |m| {
-                reply.to_prefix(m);
-                m
-            })
-            .await?;
-        if let Some(track_edits) = &mut lock_edit_tracker() {
-            track_edits.set_bot_response(ctx.msg, new_response.clone());
-        }
-
-        new_response
-    }))
+    inner(ctx, reply).await
 }

--- a/src/slash/mod.rs
+++ b/src/slash/mod.rs
@@ -18,12 +18,54 @@ pub async fn send_application_reply<'a, U, E>(
     ctx: ApplicationContext<'_, U, E>,
     builder: impl for<'b> FnOnce(&'b mut crate::CreateReply<'a>) -> &'b mut crate::CreateReply<'a>,
 ) -> Result<crate::ReplyHandle<'_>, serenity::Error> {
-    let interaction = match ctx.interaction {
-        crate::ApplicationCommandOrAutocompleteInteraction::ApplicationCommand(x) => x,
-        crate::ApplicationCommandOrAutocompleteInteraction::Autocomplete(_) => {
-            return Ok(crate::ReplyHandle::Autocomplete)
+    // inner function that isn't generic over the builer to minimize monomorphization-related codegen bloat
+    async fn inner<'a, 'b, U, E>(
+        ctx: ApplicationContext<'b, U, E>,
+        mut data: crate::CreateReply<'a>,
+    ) -> Result<crate::ReplyHandle<'b>, serenity::Error> {
+        let interaction = match ctx.interaction {
+            crate::ApplicationCommandOrAutocompleteInteraction::ApplicationCommand(x) => x,
+            crate::ApplicationCommandOrAutocompleteInteraction::Autocomplete(_) => {
+                return Ok(crate::ReplyHandle::Autocomplete)
+            }
+        };
+
+        if let Some(callback) = ctx.framework.options().reply_callback {
+            callback(ctx.into(), &mut data);
         }
-    };
+
+        let has_sent_initial_response = ctx
+            .has_sent_initial_response
+            .load(std::sync::atomic::Ordering::SeqCst);
+
+        Ok(if has_sent_initial_response {
+            crate::ReplyHandle::Known(Box::new(
+                interaction
+                    .create_followup_message(ctx.discord, |f| {
+                        data.to_slash_followup_response(f);
+                        f
+                    })
+                    .await?,
+            ))
+        } else {
+            interaction
+                .create_interaction_response(ctx.discord, |r| {
+                    r.kind(serenity::InteractionResponseType::ChannelMessageWithSource)
+                        .interaction_response_data(|f| {
+                            data.to_slash_initial_response(f);
+                            f
+                        })
+                })
+                .await?;
+            ctx.has_sent_initial_response
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+
+            crate::ReplyHandle::Unknown {
+                http: &ctx.discord.http,
+                interaction,
+            }
+        })
+    }
 
     let mut data = crate::CreateReply {
         ephemeral: ctx.command.ephemeral,
@@ -31,39 +73,5 @@ pub async fn send_application_reply<'a, U, E>(
         ..Default::default()
     };
     builder(&mut data);
-    if let Some(callback) = ctx.framework.options().reply_callback {
-        callback(ctx.into(), &mut data);
-    }
-
-    let has_sent_initial_response = ctx
-        .has_sent_initial_response
-        .load(std::sync::atomic::Ordering::SeqCst);
-
-    Ok(if has_sent_initial_response {
-        crate::ReplyHandle::Known(Box::new(
-            interaction
-                .create_followup_message(ctx.discord, |f| {
-                    data.to_slash_followup_response(f);
-                    f
-                })
-                .await?,
-        ))
-    } else {
-        interaction
-            .create_interaction_response(ctx.discord, |r| {
-                r.kind(serenity::InteractionResponseType::ChannelMessageWithSource)
-                    .interaction_response_data(|f| {
-                        data.to_slash_initial_response(f);
-                        f
-                    })
-            })
-            .await?;
-        ctx.has_sent_initial_response
-            .store(true, std::sync::atomic::Ordering::SeqCst);
-
-        crate::ReplyHandle::Unknown {
-            http: &ctx.discord.http,
-            interaction,
-        }
-    })
+    inner(ctx, data).await
 }

--- a/src/slash/mod.rs
+++ b/src/slash/mod.rs
@@ -27,7 +27,7 @@ pub async fn send_application_reply<'a, U, E>(
     _send_application_reply(ctx, data).await
 }
 
-// private function that isn't generic over the builder to minimize monomorphization-related codegen bloat
+/// private version of [`send_application_reply`] that isn't generic over the builder to minimize monomorphization-related codegen bloat
 async fn _send_application_reply<'a, 'b, U, E>(
     ctx: ApplicationContext<'b, U, E>,
     mut data: crate::CreateReply<'a>,


### PR DESCRIPTION
the send_application_reply and send_prefix_reply functions are quite long, very commonly called functions, which are generic over their respective builder function. 
During monomorphization, these function bodies get duplicated for each different closure passed to the functions, thus causing a lot of unnecessary codegen output.
By putting most of the function body into a non-generic inner function, we can minimize the impact of this, resulting in a noticable decrease in generated LLVM.