### PR TITLE
Add intercept_dispatch to FrameworkOptions

### DIFF
--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -113,14 +113,15 @@ impl<U, E> Framework<U, E> {
                     ctx,
                     event,
                     &*framework,
-                    Box::new(move |ctx, event, framework| {
+                    existing_event_handler,
+                    |ctx, event, framework, existing_event_handler| {
                         Box::pin(async move {
                             dispatch::dispatch_event(framework, &ctx, &event).await;
                             if let Some(handler) = existing_event_handler {
                                 event.dispatch(ctx, &*handler).await;
                             }
                         })
-                    }),
+                    },
                 )
                 .await;
             }) as _

--- a/src/structs/framework_options.rs
+++ b/src/structs/framework_options.rs
@@ -15,7 +15,7 @@ pub struct FrameworkOptions<U, E> {
     /// Provide a callback to wrap all event dispatch logic in your own code.
     ///
     /// Simply forwards the event dispatch call by default:
-    /// ```rust
+    /// ```rust,ignore
     /// |ctx, event, framework, handler, dispatch_fn| {
     ///     Box::pin(async move {
     ///         dispatch_fn(ctx, event, framework, handler).await;


### PR DESCRIPTION
This PR adds a new option to the FrameworkOptions struct: `intercept_dispatch`.
This allows users to wrap the entire event-dispatch logic in their own code.
For my project, this is required to allow us to properly provide contextual log-traces.
Additionally, this could be useful to add additional checks and profiling or debugging-related logic to the event dispatch system,
as well as possibly making some other operations possible that would previously have depended on adding more specific features to poise.