### PR TITLE
Fix default_member_permissions

### DIFF
--- a/macros/src/command/mod.rs
+++ b/macros/src/command/mod.rs
@@ -172,19 +172,18 @@ pub fn command(
 
     fn permissions_to_tokens(
         perms: &Option<syn::punctuated::Punctuated<syn::Ident, syn::Token![|]>>,
-        empty_perms: bool
     ) -> syn::Expr {
-        match perms.as_ref().map(syn::punctuated::Punctuated::iter) {
-            Some(perms) if empty_perms => syn::parse_quote! { #(poise::serenity_prelude::Permissions::#perms)|* },
-            Some(perms) =>  syn::parse_quote! { Some(#(poise::serenity_prelude::Permissions::#perms)|*) },
-            None if empty_perms => syn::parse_quote! { poise::serenity_prelude::Permissions::empty() },
-            None => syn::parse_quote! { None },
+        match perms {
+            Some(perms) => {
+                let perms = perms.iter();
+                syn::parse_quote! { #(poise::serenity_prelude::Permissions::#perms)|* }
+            }
+            None => syn::parse_quote! { poise::serenity_prelude::Permissions::empty() },
         }
     }
-
-    let default_member_permissions = permissions_to_tokens(&args.default_member_permissions, false);
-    let required_bot_permissions = permissions_to_tokens(&args.required_bot_permissions, true);
-    let required_permissions = permissions_to_tokens(&args.required_permissions, true);
+    let default_member_permissions = permissions_to_tokens(&args.default_member_permissions);
+    let required_permissions = permissions_to_tokens(&args.required_permissions);
+    let required_bot_permissions = permissions_to_tokens(&args.required_bot_permissions);
 
     let inv = Invocation {
         command_name: args

--- a/src/structs/command.rs
+++ b/src/structs/command.rs
@@ -61,7 +61,9 @@ pub struct Command<U, E> {
     pub reuse_response: bool,
     /// Permissions which users must have to invoke this command. Used by Discord to set who can
     /// invoke this as a slash command. Not used on prefix commands or checked internally.
-    pub default_member_permissions: Option<serenity::Permissions>,
+    ///
+    /// Set to [`serenity::Permissions::empty()`] by default
+    pub default_member_permissions: serenity::Permissions,
     /// Permissions which users must have to invoke this command. This is checked internally and
     /// works for both prefix commands and slash commands.
     ///
@@ -164,8 +166,10 @@ impl<U, E> Command<U, E> {
             .name(self.name)
             .description(self.inline_help.unwrap_or("A slash command"));
 
-        if let Some(default_member_permissions) = self.default_member_permissions {
-            builder.default_member_permissions(default_member_permissions);
+        // This is_empty check is needed because Discord special cases empty
+        // default_member_permissions to mean "admin-only" (yes it's stupid)
+        if !self.default_member_permissions.is_empty() {
+            builder.default_member_permissions(self.default_member_permissions);
         }
 
         if self.subcommands.is_empty() {

--- a/src/structs/command.rs
+++ b/src/structs/command.rs
@@ -61,9 +61,7 @@ pub struct Command<U, E> {
     pub reuse_response: bool,
     /// Permissions which users must have to invoke this command. Used by Discord to set who can
     /// invoke this as a slash command. Not used on prefix commands or checked internally.
-    ///
-    /// Set to [`serenity::Permissions::empty()`] by default
-    pub default_member_permissions: serenity::Permissions,
+    pub default_member_permissions: Option<serenity::Permissions>,
     /// Permissions which users must have to invoke this command. This is checked internally and
     /// works for both prefix commands and slash commands.
     ///
@@ -164,8 +162,11 @@ impl<U, E> Command<U, E> {
         let mut builder = serenity::CreateApplicationCommand::default();
         builder
             .name(self.name)
-            .description(self.inline_help.unwrap_or("A slash command"))
-            .default_member_permissions(self.default_member_permissions);
+            .description(self.inline_help.unwrap_or("A slash command"));
+
+        if let Some(default_member_permissions) = self.default_member_permissions {
+            builder.default_member_permissions(default_member_permissions);
+        }
 
         if self.subcommands.is_empty() {
             for param in &self.parameters {


### PR DESCRIPTION
Permissions::empty means only admins can run the command, not that there are no permission requirements. Only not supplying the field allows anyone to use the command.