### PR TITLE
Don't pull in chrono by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ derivative = "2.2.0"
 
 [dependencies.serenity]
 default-features = false
-features = ["builder", "client", "gateway", "model", "utils", "collector", "chrono"]
+features = ["builder", "client", "gateway", "model", "utils", "collector"]
 
 version = "0.11.2"
 
@@ -42,10 +42,12 @@ futures = { version = "0.3.13", default-features = false }
 env_logger = "0.9.0"
 
 [features]
-default = ["serenity/rustls_backend", "cache"]
+default = ["serenity/rustls_backend", "cache", "time"]
+chrono = ["serenity/chrono"]
+cache = ["serenity/cache"]
+time = ["serenity/time"]
 # No-op feature because serenity/collector is now enabled by default
 collector = []
-cache = ["serenity/cache"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/structs/context.rs
+++ b/src/structs/context.rs
@@ -196,6 +196,7 @@ impl<'a, U, E> Context<'a, U, E> {
     }
 
     /// Return a ID that uniquely identifies this command invocation.
+    #[cfg(any(feature = "chrono", feature = "time"))]
     pub fn id(&self) -> u64 {
         match self {
             Self::Application(ctx) => ctx.interaction.id().0,
@@ -210,7 +211,14 @@ impl<'a, U, E> Context<'a, U, E> {
 
                     // Calculate Discord's datetime representation (millis since Discord epoch) and
                     // insert those bits into the ID
-                    id |= ((edited_timestamp.timestamp_millis() - 1420070400000) as u64) << 22;
+
+                    #[cfg(feature = "chrono")]
+                    let timestamp_millis = edited_timestamp.timestamp_millis();
+
+                    #[cfg(feature = "time")]
+                    let timestamp_millis = edited_timestamp.unix_timestamp_nanos() / 1_000_000;
+
+                    id |= ((timestamp_millis - 1420070400000) as u64) << 22;
                 }
                 id
             }

--- a/src/structs/context.rs
+++ b/src/structs/context.rs
@@ -212,11 +212,11 @@ impl<'a, U, E> Context<'a, U, E> {
                     // Calculate Discord's datetime representation (millis since Discord epoch) and
                     // insert those bits into the ID
 
-                    #[cfg(feature = "chrono")]
-                    let timestamp_millis = edited_timestamp.timestamp_millis();
-
                     #[cfg(feature = "time")]
                     let timestamp_millis = edited_timestamp.unix_timestamp_nanos() / 1_000_000;
+
+                    #[cfg(not(feature = "time"))]
+                    let timestamp_millis = edited_timestamp.timestamp_millis();
 
                     id |= ((timestamp_millis - 1420070400000) as u64) << 22;
                 }


### PR DESCRIPTION
Avoids pulling in the unmaintained and vulnerable chrono library via a serenity feature by default