### PR TITLE
Allow getting reference to inner message object easier

### DIFF
--- a/src/builtins/register.rs
+++ b/src/builtins/register.rs
@@ -152,7 +152,9 @@ pub async fn register_application_commands_buttons<U, E>(
         })
         .await?;
 
-    let interaction = reply.message().await?
+    let interaction = reply
+        .message()
+        .await?
         .await_component_interaction(ctx.discord())
         .author_id(ctx.author().id)
         .await;

--- a/src/builtins/register.rs
+++ b/src/builtins/register.rs
@@ -120,7 +120,7 @@ pub async fn register_application_commands_buttons<U, E>(
         return Ok(());
     }
 
-    let mut msg = ctx
+    let reply = ctx
         .send(|m| {
             m.content("Choose what to do with the commands:")
                 .components(|c| {
@@ -150,15 +150,14 @@ pub async fn register_application_commands_buttons<U, E>(
                     })
                 })
         })
-        .await?
-        .message()
         .await?;
 
-    let interaction = msg
+    let interaction = reply.message().await?
         .await_component_interaction(ctx.discord())
         .author_id(ctx.author().id)
         .await;
-    msg.edit(ctx.discord(), |b| b.components(|b| b)).await?; // remove buttons after button press
+
+    reply.edit(ctx, |b| b.components(|b| b)).await?; // remove buttons after button press
     let pressed_button_id = match &interaction {
         Some(m) => &m.data.custom_id,
         None => {

--- a/src/reply/mod.rs
+++ b/src/reply/mod.rs
@@ -36,6 +36,7 @@ pub enum ReplyHandle<'a> {
 impl ReplyHandle<'_> {
     #[cold]
     #[track_caller]
+    /// Panics for when the variant is autocomplete
     fn autocomplete_panic() -> ! {
         panic!("reply is a no-op in autocomplete context")
     }

--- a/src/reply/mod.rs
+++ b/src/reply/mod.rs
@@ -34,13 +34,6 @@ pub enum ReplyHandle<'a> {
 }
 
 impl ReplyHandle<'_> {
-    #[cold]
-    #[track_caller]
-    /// Panics for when the variant is autocomplete
-    fn autocomplete_panic() -> ! {
-        panic!("reply is a no-op in autocomplete context")
-    }
-
     /// Retrieve the message object of the sent reply.
     ///
     /// If you don't need ownership of Message, you can use [`ReplyHandle::message`]
@@ -50,7 +43,7 @@ impl ReplyHandle<'_> {
         match self {
             Self::Known(msg) => Ok(*msg),
             Self::Unknown { http, interaction } => interaction.get_interaction_response(http).await,
-            Self::Autocomplete => Self::autocomplete_panic(),
+            Self::Autocomplete => panic!("reply is a no-op in autocomplete context"),
         }
     }
 
@@ -63,7 +56,7 @@ impl ReplyHandle<'_> {
             Self::Unknown { http, interaction } => Ok(Cow::Owned(
                 interaction.get_interaction_response(http).await?,
             )),
-            Self::Autocomplete => Self::autocomplete_panic(),
+            Self::Autocomplete => panic!("reply is a no-op in autocomplete context"),
         }
     }
 
@@ -102,7 +95,7 @@ impl ReplyHandle<'_> {
                     })
                     .await?;
             }
-            Self::Autocomplete => Self::autocomplete_panic(),
+            Self::Autocomplete => panic!("reply is a no-op in autocomplete context"),
         }
         Ok(())
     }


### PR DESCRIPTION
This renames `ReplyHandle::message` to `ReplyHandle::into_message` and adds `ReplyHandle::message` to return `Cow<Message>`. 