### PR TITLE
Enable manual sharding configurations using `Framework::start_with`

### DIFF
--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -1,9 +1,10 @@
 //! The central Framework struct that ties everything together.
 
-mod builder;
 pub use builder::*;
 
 use crate::{serenity_prelude as serenity, BoxFuture};
+
+mod builder;
 
 /// The main framework struct which stores all data and handles message and interaction dispatch.
 ///
@@ -128,32 +129,29 @@ impl<U, E> Framework<U, E> {
     ///
     /// See [`Framework::start`] or [`Framework::start_autosharded`]
     ///
-    /// For other sharding configuration see the following examples
-    /// ```rust,no_run
-    /// use serenity::prelude::GatewayIntents;
-    /// use poise::{Framework, FrameworkOptions};
+    /// # Examples
     ///
-    /// let framework = Framework::builder()
-    ///     // Required values
+    /// Start shards in a range
+    /// ```rust,no_run
+    /// # use std::sync::Arc;
+    /// # use poise::serenity_prelude as serenity;
+    /// # type Error = Box<dyn std::error::Error + Send + Sync>;
+    /// # type Context<'a> = poise::Context<'a, (), Error>;
+    /// # async {
+    /// let framework: Arc<poise::Framework<(), Error>> = poise::Framework::builder()
+    ///     .options(poise::FrameworkOptions { ..Default::default() })
+    ///     .token("...")
+    ///     .intents(serenity::GatewayIntents::non_privileged())
+    ///     .user_data_setup(|_, _, _| Box::pin(async move { Ok(()) }))
     ///     .build()
     ///     .await?;
     ///
-    /// // Shard with id
-    /// let (id, total_count) = (2, 5);
-    /// framework.start_with(|mut c| async move { c.start_shard(id, total_count).await })
-    ///     .await?;
+    /// let shard_range = [3, 7];
+    /// let total_shards = 8;
     ///
-    /// // Number of shards
-    /// let total_count = 4;
-    /// framework.start_with(|mut c| async move { c.start_shards(total_count).await })
-    ///     .await?;
+    /// framework.start_with(|mut client| async move { client.start_shard_range(shard_range, total_shards).await }).await?;
     ///
-    /// // Shard range
-    /// let range = [3, 7];
-    /// let total_count = 8;
-    /// framework.start_with(|mut c| async move { c.start_shard_range(range, total_count).await })
-    ///     .await?;
-    ///
+    /// # Ok::<(), Error>(()) };
     /// ```
     pub async fn start_with<F: std::future::Future<Output = serenity::Result<()>>>(
         self: std::sync::Arc<Self>,

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -126,7 +126,7 @@ impl<U, E> Framework<U, E> {
     /// Used internally by [`Self::start()`] and [`Self::start_autosharded()`]
     pub async fn start_with<F: std::future::Future<Output = serenity::Result<()>>>(
         self: std::sync::Arc<Self>,
-        start: fn(serenity::Client) -> F,
+        start: impl FnOnce(serenity::Client) -> F,
     ) -> Result<(), serenity::Error>
     where
         U: Send + Sync + 'static,

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -124,34 +124,23 @@ impl<U, E> Framework<U, E> {
 
     /// Small utility function for starting the framework that is agnostic over client sharding
     ///
-    /// You can use these shortcut methods to start the framework a single shard
-    /// or with automatic sharding.
-    ///
-    /// See [`Framework::start`] or [`Framework::start_autosharded`]
+    /// You can use these shortcut methods to start the framework with a single shard
+    /// or with automatic sharding: [`Framework::start`], [`Framework::start_autosharded`]
     ///
     /// # Examples
     ///
     /// Start shards in a range
     /// ```rust,no_run
-    /// # use std::sync::Arc;
-    /// # use poise::serenity_prelude as serenity;
-    /// # type Error = Box<dyn std::error::Error + Send + Sync>;
-    /// # type Context<'a> = poise::Context<'a, (), Error>;
-    /// # async {
-    /// let framework: Arc<poise::Framework<(), Error>> = poise::Framework::builder()
-    ///     .options(poise::FrameworkOptions { ..Default::default() })
-    ///     .token("...")
-    ///     .intents(serenity::GatewayIntents::non_privileged())
-    ///     .user_data_setup(|_, _, _| Box::pin(async move { Ok(()) }))
-    ///     .build()
-    ///     .await?;
-    ///
+    /// # async fn _test(framework: std::sync::Arc<poise::Framework<(), ()>>) -> Result<(), serenity::Error> {
     /// let shard_range = [3, 7];
     /// let total_shards = 8;
     ///
-    /// framework.start_with(|mut client| async move { client.start_shard_range(shard_range, total_shards).await }).await?;
-    ///
-    /// # Ok::<(), Error>(()) };
+    /// framework
+    ///     .start_with(|mut client| async move {
+    ///         client.start_shard_range(shard_range, total_shards).await
+    ///    })
+    ///    .await?;
+    /// # Ok(()) };
     /// ```
     pub async fn start_with<F: std::future::Future<Output = serenity::Result<()>>>(
         self: std::sync::Arc<Self>,

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -123,7 +123,38 @@ impl<U, E> Framework<U, E> {
 
     /// Small utility function for starting the framework that is agnostic over client sharding
     ///
-    /// Used internally by [`Self::start()`] and [`Self::start_autosharded()`]
+    /// You can use these shortcut methods to start the framework a single shard
+    /// or with automatic sharding.
+    ///
+    /// See [`Framework::start`] or [`Framework::start_autosharded`]
+    ///
+    /// For other sharding configuration see the following examples
+    /// ```rust,no_run
+    /// use serenity::prelude::GatewayIntents;
+    /// use poise::{Framework, FrameworkOptions};
+    ///
+    /// let framework = Framework::builder()
+    ///     // Required values
+    ///     .build()
+    ///     .await?;
+    ///
+    /// // Shard with id
+    /// let (id, total_count) = (2, 5);
+    /// framework.start_with(|mut c| async move { c.start_shard(id, total_count).await })
+    ///     .await?;
+    ///
+    /// // Number of shards
+    /// let total_count = 4;
+    /// framework.start_with(|mut c| async move { c.start_shards(total_count).await })
+    ///     .await?;
+    ///
+    /// // Shard range
+    /// let range = [3, 7];
+    /// let total_count = 8;
+    /// framework.start_with(|mut c| async move { c.start_shard_range(range, total_count).await })
+    ///     .await?;
+    ///
+    /// ```
     pub async fn start_with<F: std::future::Future<Output = serenity::Result<()>>>(
         self: std::sync::Arc<Self>,
         start: impl FnOnce(serenity::Client) -> F,
@@ -147,7 +178,9 @@ impl<U, E> Framework<U, E> {
         Ok(())
     }
 
-    /// Starts the framework.
+    /// Starts the framework with a shard. Calls [`serenity::Client::start`] internally.
+    ///
+    /// See [`Framework::start_with`] for other sharding configurations.
     pub async fn start(self: std::sync::Arc<Self>) -> Result<(), serenity::Error>
     where
         U: Send + Sync + 'static,
@@ -157,7 +190,10 @@ impl<U, E> Framework<U, E> {
             .await
     }
 
-    /// Starts the framework. Calls [`serenity::Client::start_autosharded`] internally
+    /// Starts the framework with automatic sharding.
+    /// Calls [`serenity::Client::start_autosharded`] internally.
+    ///
+    /// See [`Framework::start_with`] for other sharding configurations.
     pub async fn start_autosharded(self: std::sync::Arc<Self>) -> Result<(), serenity::Error>
     where
         U: Send + Sync + 'static,


### PR DESCRIPTION
<!-- please base the PR on the develop branch if possible 😇 -->
Adds methods to start the framework with different sharding configurations available in the `serenity::Client`