### PR TITLE
Rename Framework build method to builder

### DIFF
--- a/examples/framework_usage/main.rs
+++ b/examples/framework_usage/main.rs
@@ -139,7 +139,7 @@ async fn main() {
         ..Default::default()
     };
 
-    poise::Framework::build()
+    poise::Framework::builder()
         .token(var("TOKEN").expect("Missing `TOKEN` env var, see README for more information."))
         .user_data_setup(move |_ctx, _ready, _framework| {
             Box::pin(async move {

--- a/examples/invocation_data/main.rs
+++ b/examples/invocation_data/main.rs
@@ -47,7 +47,7 @@ pub async fn invocation_data_test(
 
 #[tokio::main]
 async fn main() {
-    poise::Framework::build()
+    poise::Framework::builder()
         .token(std::env::var("TOKEN").unwrap())
         .user_data_setup(move |ctx, _, framework| {
             Box::pin(async move {

--- a/examples/quickstart/main.rs
+++ b/examples/quickstart/main.rs
@@ -25,7 +25,7 @@ async fn register(ctx: Context<'_>) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() {
-    let framework = poise::Framework::build()
+    let framework = poise::Framework::builder()
         .options(poise::FrameworkOptions {
             commands: vec![age(), register()],
             ..Default::default()

--- a/examples/serenity_example_port/main.rs
+++ b/examples/serenity_example_port/main.rs
@@ -286,7 +286,7 @@ async fn main() {
 
     // The Framework builder will automatically retrieve the bot owner and application ID via the
     // passed token, so that information need not be passed here
-    poise::Framework::build()
+    poise::Framework::builder()
         // Configure the client with your Discord bot token in the environment.
         .token(std::env::var("DISCORD_TOKEN").expect("Expected DISCORD_TOKEN in the environment"))
         .options(options)

--- a/src/framework/builder.rs
+++ b/src/framework/builder.rs
@@ -139,7 +139,7 @@ impl<U, E> FrameworkBuilder<U, E> {
     /// # async fn command2(ctx: poise::Context<'_, (), Error>) -> Result<(), Error> { Ok(()) }
     ///
     /// # #[allow(deprecated)] // just for this example
-    /// poise::Framework::build()
+    /// poise::Framework::builder()
     ///     // framework setup...
     ///     .commands([command1, command2])
     ///     // framework startup...

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -47,7 +47,15 @@ impl<U, E> Framework<U, E> {
     /// Create a framework builder to configure, create and run a framework.
     ///
     /// For more information, see [`FrameworkBuilder`]
+    #[deprecated = "Please use Framework::builder instead"]
     pub fn build() -> FrameworkBuilder<U, E> {
+        FrameworkBuilder::default()
+    }
+
+    /// Create a framework builder to configure, create and run a framework.
+    ///
+    /// For more information, see [`FrameworkBuilder`]
+    pub fn builder() -> FrameworkBuilder<U, E> {
         FrameworkBuilder::default()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,8 +130,8 @@ async fn error_handler(error: poise::FrameworkError<'_, Data, Error>) {
 # #[poise::command(prefix_command)] async fn command3(ctx: Context<'_>) -> Result<(), Error> { Ok(()) }
 
 # async {
-// Use `Framework::build()` to create a framework builder and supply basic data to the framework:
-poise::Framework::build()
+// Use `Framework::builder()` to create a framework builder and supply basic data to the framework:
+poise::Framework::builder()
     .token("...")
     .user_data_setup(|_, _, _| Box::pin(async move {
         // construct user data here (invoked when bot connects to Discord)


### PR DESCRIPTION
<!-- please base the PR on the develop branch if possible 😇 -->
Deprecate `Framework::build` in favour of `Framework::builder`, this would be more in line with the common standard (at least from what I've seen).