### PR TITLE
fix: to_string in command macro clashes with lint clippy::str_to_string

### DIFF
--- a/macros/src/command/mod.rs
+++ b/macros/src/command/mod.rs
@@ -313,7 +313,7 @@ fn generate_command(mut inv: Invocation) -> Result<proc_macro2::TokenStream, dar
                 context_menu_action: #context_menu_action,
 
                 subcommands: vec![ #( #subcommands() ),* ],
-                name: #command_name.to_string(),
+                name: #command_name.to_owned(),
                 name_localizations: #name_localizations,
                 qualified_name: String::from(#command_name), // properly filled in later by Framework
                 identifying_name: String::from(#identifying_name),


### PR DESCRIPTION
HI there,

I have a Clippy lint that clashes with the generated code in the command macro. Here is the Clippy lint page: https://rust-lang.github.io/rust-clippy/master/index.html#str_to_string
The other way of doing so is by adding a `#[allow(clippy::str_to_string)]` before the expression.

I can make the other change if wanted

Thanks for your time