### PR TITLE
add poise::Context::category_id

### DIFF
--- a/src/structs/context.rs
+++ b/src/structs/context.rs
@@ -136,16 +136,16 @@ impl<'a, U, E> Context<'a, U, E> {
     }
 
     /// Return the category ID of this context, if we are inside a category
+    ///
+    /// If we're not in a category channel, or not even in a guild, Ok(None) is returned.
+    /// If retrieving channel data failed, Err(...) is returned.
     pub async fn category_id(&self) -> Result<Option<serenity::ChannelId>, serenity::Error> {
-        let chan = self.discord().cache.channel(self.channel_id());
-        let chan = match chan {
-            Some(chan) => chan,
-            None => self.discord().http.get_channel(self.channel_id().0).await?,
-        };
-        Ok(match chan {
-            serenity::Channel::Guild(chan) => chan.parent_id,
-            _ => None
-        })
+        Ok(self
+            .channel_id()
+            .to_channel(self.discord())
+            .await?
+            .guild()
+            .and_then(|chan| chan.parent_id))
     }
 
     /// Returns the guild ID of this context, if we are inside a guild

--- a/src/structs/context.rs
+++ b/src/structs/context.rs
@@ -135,6 +135,19 @@ impl<'a, U, E> Context<'a, U, E> {
         }
     }
 
+    /// Return the category ID of this context, if we are inside a category
+    pub async fn category_id(&self) -> Result<Option<serenity::ChannelId>, serenity::Error> {
+        let chan = self.discord().cache.channel(self.channel_id());
+        let chan = match chan {
+            Some(chan) => chan,
+            None => self.discord().http.get_channel(self.channel_id().0).await?,
+        };
+        Ok(match chan {
+            serenity::Channel::Guild(chan) => chan.parent_id,
+            _ => None
+        })
+    }
+
     /// Returns the guild ID of this context, if we are inside a guild
     pub fn guild_id(&self) -> Option<serenity::GuildId> {
         match self {


### PR DESCRIPTION
It'd be nice if we could easily fetch the containing category for the channel a command is invoked in.
This method tolerates the Serenity cache not being populated (and thus has to be `async` in order to fetch that info from Discord).

<!-- please base the PR on the develop branch if possible 😇 -->
