### PR TITLE
fix broken serenity event handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "serenity"
 version = "0.11.5"
-source = "git+https://github.com/serenity-rs/serenity?branch=next#845334bc1869efa1fc3fcac0ef83cee99075fec7"
+source = "git+https://github.com/serenity-rs/serenity?branch=next#d1911a91cbcb74d588008da78c0692b98e3721fd"
 dependencies = [
  "async-trait",
  "base64",

--- a/src/event.rs
+++ b/src/event.rs
@@ -81,8 +81,6 @@ event! {
     #[cfg(feature = "cache")]
     cache_ready => CacheReady { guilds: Vec<serenity::GuildId> },
     channel_create<'a> => ChannelCreate { channel: &'a serenity::GuildChannel },
-    category_create<'a> => CategoryCreate { category: &'a serenity::ChannelCategory },
-    category_delete<'a> => CategoryDelete { category: &'a serenity::ChannelCategory },
     channel_delete<'a> => ChannelDelete { channel: &'a serenity::GuildChannel },
     channel_pins_update => ChannelPinsUpdate { pin: serenity::ChannelPinsUpdateEvent },
     #[cfg(feature = "cache")]

--- a/src/event.rs
+++ b/src/event.rs
@@ -81,6 +81,8 @@ event! {
     #[cfg(feature = "cache")]
     cache_ready => CacheReady { guilds: Vec<serenity::GuildId> },
     channel_create<'a> => ChannelCreate { channel: &'a serenity::GuildChannel },
+    category_create<'a> => CategoryCreate { category: &'a serenity::GuildChannel },
+    category_delete<'a> => CategoryDelete { category: &'a serenity::GuildChannel },
     channel_delete<'a> => ChannelDelete { channel: &'a serenity::GuildChannel },
     channel_pins_update => ChannelPinsUpdate { pin: serenity::ChannelPinsUpdateEvent },
     #[cfg(feature = "cache")]


### PR DESCRIPTION
Serenity seems to have had a recent update that removed the CategoryCreate and CategoryDelete Event enum variants. This PR removes those variants as well. Tested by checking if the lib compiles.