### PR TITLE
Bump Tokio and Regex versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ license = "MIT"
 repository = "https://github.com/kangalioo/poise/"
 
 [dependencies]
-tokio = { version = "1.4.0", default-features = false } # for async in general
+tokio = { version = "1.21.1", default-features = false } # for async in general
 futures-core = { version = "0.3.13", default-features = false } # for async in general
 futures-util = { version = "0.3.13", default-features = false } # for async in general
 once_cell = { version = "1.7.2", default-features = false, features = ["std"] } # to store and set user data
 poise_macros = { path = "macros", version = "0.3.0" } # remember to update the version on changes!
 async-trait = { version = "0.1.48", default-features = false } # various traits
-regex = { version = "1.5.4", default-features = false, features = ["std"] } # prefix
+regex = { version = "1.6.0", default-features = false, features = ["std"] } # prefix
 log = { version = "0.4.14", default-features = false } # warning about weird state
 derivative = "2.2.0"
 parking_lot = "0.12.1"
@@ -38,7 +38,7 @@ version = "0.11.4"
 
 [dev-dependencies]
 # For the examples
-tokio = { version = "1.4.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.21.1", features = ["rt-multi-thread"] }
 futures = { version = "0.3.13", default-features = false }
 env_logger = "0.9.0"
 fluent = "0.16.0"


### PR DESCRIPTION
Updating Tokio ensures [RUSTSEC-2021-0124](https://rustsec.org/advisories/RUSTSEC-2021-0124.html) will not happen if `tokio::sync::oneshot` is used in the future

Updating Regex fixes [RUSTSEC-2022-0013](https://rustsec.org/advisories/RUSTSEC-2022-0013.html) which allows DOS attack/issues. better safe than sorry.

~~I don't know why the commit is `Unverified` I made the change through GitHub's web editor so it would automatically create the fork~~