### PR TITLE
Generate unique IDs for modals

### DIFF
--- a/macros/src/modal.rs
+++ b/macros/src/modal.rs
@@ -105,11 +105,11 @@ pub fn modal(input: syn::DeriveInput) -> Result<TokenStream, darling::Error> {
     Ok(quote::quote! { const _: () = {
         use poise::serenity_prelude as serenity;
         impl #impl_generics poise::Modal for #struct_ident #ty_generics #where_clause {
-            fn create(mut defaults: Option<Self>) -> serenity::CreateInteractionResponse<'static> {
+            fn create(mut defaults: Option<Self>, custom_id: Option<String>) -> serenity::CreateInteractionResponse<'static> {
                 let mut b = serenity::CreateInteractionResponse::default();
                 b.kind(serenity::InteractionResponseType::Modal);
                 b.interaction_response_data(|b| {
-                    b.custom_id("0").title(#modal_title).components(|b| b #( #builders )* )
+                    b.custom_id(custom_id.unwrap_or("0".to_string())).title(#modal_title).components(|b| b #( #builders )* )
                 });
                 b
             }

--- a/macros/src/modal.rs
+++ b/macros/src/modal.rs
@@ -105,11 +105,11 @@ pub fn modal(input: syn::DeriveInput) -> Result<TokenStream, darling::Error> {
     Ok(quote::quote! { const _: () = {
         use poise::serenity_prelude as serenity;
         impl #impl_generics poise::Modal for #struct_ident #ty_generics #where_clause {
-            fn create(mut defaults: Option<Self>, custom_id: Option<String>) -> serenity::CreateInteractionResponse<'static> {
+            fn create(mut defaults: Option<Self>, custom_id: String) -> serenity::CreateInteractionResponse<'static> {
                 let mut b = serenity::CreateInteractionResponse::default();
                 b.kind(serenity::InteractionResponseType::Modal);
                 b.interaction_response_data(|b| {
-                    b.custom_id(custom_id.unwrap_or("0".to_string())).title(#modal_title).components(|b| b #( #builders )* )
+                    b.custom_id(custom_id).title(#modal_title).components(|b| b #( #builders )* )
                 });
                 b
             }

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -46,7 +46,7 @@ async fn execute<U: Send + Sync, E, M: Modal>(
     // Send modal
     interaction
         .create_interaction_response(ctx.discord, |b| {
-            *b = M::create(defaults, interaction.id.to_string());
+            *b = M::create(defaults, interaction_id.clone());
             b
         })
         .await?;

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -109,7 +109,10 @@ pub trait Modal: Sized {
     ///
     /// Optionally takes an initialized instance as pre-filled values of this modal (see
     /// [`Self::execute_with_defaults()`] for more info)
-    fn create(defaults: Option<Self>, custom_id: Option<String>) -> serenity::CreateInteractionResponse<'static>;
+    fn create(
+        defaults: Option<Self>,
+        custom_id: String,
+    ) -> serenity::CreateInteractionResponse<'static>;
 
     /// Parses a received modal submit interaction into this type
     ///

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -41,11 +41,12 @@ async fn execute<U: Send + Sync, E, M: Modal>(
     defaults: Option<M>,
 ) -> Result<M, serenity::Error> {
     let interaction = ctx.interaction.unwrap();
+    let interaction_id = interaction.id.to_string();
 
     // Send modal
     interaction
         .create_interaction_response(ctx.discord, |b| {
-            *b = M::create(defaults);
+            *b = M::create(defaults, Some(interaction_id.clone()));
             b
         })
         .await?;
@@ -54,7 +55,7 @@ async fn execute<U: Send + Sync, E, M: Modal>(
 
     // Wait for user to submit
     let response = serenity::CollectModalInteraction::new(&ctx.discord.shard)
-        .author_id(interaction.user.id)
+        .filter(move |d| d.data.custom_id == interaction_id)
         .await
         .unwrap();
 
@@ -108,7 +109,7 @@ pub trait Modal: Sized {
     ///
     /// Optionally takes an initialized instance as pre-filled values of this modal (see
     /// [`Self::execute_with_defaults()`] for more info)
-    fn create(defaults: Option<Self>) -> serenity::CreateInteractionResponse<'static>;
+    fn create(defaults: Option<Self>, custom_id: Option<String>) -> serenity::CreateInteractionResponse<'static>;
 
     /// Parses a received modal submit interaction into this type
     ///

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -46,7 +46,7 @@ async fn execute<U: Send + Sync, E, M: Modal>(
     // Send modal
     interaction
         .create_interaction_response(ctx.discord, |b| {
-            *b = M::create(defaults, Some(interaction_id.clone()));
+            *b = M::create(defaults, interaction.id.to_string());
             b
         })
         .await?;


### PR DESCRIPTION
## Issue
When a modal is created using `Modal::execute` or `execute_with_defaults`, the user can close the modal prompt, re-execute the command to receive another modal, and finally submit the modal. When this happens, poise will attempt to respond to the interaction twice.

## Reproduction
1. [Using the example modal code](https://github.com/kangalioo/poise/blob/162ac53094d1daec4e96f67980aaf50823e6f46a/examples/framework_usage/commands/general.rs#L280-L296), register the modal command and execute it
2. Close the modal without submitting (`X` in the top right of the modal, `Cancel`, press ESC, back button, etc.)
3. Execute the modal command again
4. Submit the modal using the `Submit` button
5. Discord will give an error on the HTTP request stating either `Unknown interaction` or `Interaction has already been acknowledged.`

## Cause
[At this point](https://github.com/kangalioo/poise/blob/5ba00794e65766a9c4d72a1560043940210b9f89/src/modal.rs#L56) a `CollectModalInteraction` collector is created which listens for modal submissions by the author. If the author closes the modal, re-opens it (thus creating another collector), and submits it, both collectors will be fulfilled and the interaction will be responded to twice.

## Solution
The solution I came up with is to set the modal's `custom_id` to the initial interaction ID, and then filter for modal submission events with the same `custom_id`. This makes it so each modal interaction collector will only collect the modal generated by the initial interaction, and not modals created from other interaction events.


This solution also solves an issue where defaults provided via `execute_with_defaults` may not be set on the client side if the user closes and re-opens the same modal. 