### PR TITLE
Enhancements for the register button command(s)

### DIFF
--- a/src/builtins/register.rs
+++ b/src/builtins/register.rs
@@ -1,4 +1,5 @@
 //! Utilities for registering application commands
+
 use crate::serenity_prelude as serenity;
 
 /// Collects all commands into a [`serenity::CreateApplicationCommands`] builder, which can be used
@@ -152,13 +153,13 @@ pub async fn register_application_commands_buttons<U, E>(
                             b.custom_id("register.guild")
                                 .label("Register in guild")
                                 .style(serenity::ButtonStyle::Primary)
-                                .emoji(serenity::ReactionType::Unicode("📋".to_string()))
+                                .emoji('📋')
                         })
                         .create_button(|b| {
                             b.custom_id("unregister.guild")
                                 .label("Delete in guild")
                                 .style(serenity::ButtonStyle::Danger)
-                                .emoji(serenity::ReactionType::Unicode("🗑️".to_string()))
+                                .emoji('🗑')
                         })
                     })
                     .create_action_row(|r| {
@@ -166,13 +167,13 @@ pub async fn register_application_commands_buttons<U, E>(
                             b.custom_id("register.global")
                                 .label("Register globally")
                                 .style(serenity::ButtonStyle::Primary)
-                                .emoji(serenity::ReactionType::Unicode("📋".to_string()))
+                                .emoji('📋')
                         })
                         .create_button(|b| {
                             b.custom_id("unregister.global")
                                 .label("Delete globally")
                                 .style(serenity::ButtonStyle::Danger)
-                                .emoji(serenity::ReactionType::Unicode("🗑️".to_string()))
+                                .emoji('🗑')
                         })
                     })
                 })
@@ -186,9 +187,7 @@ pub async fn register_application_commands_buttons<U, E>(
         .author_id(ctx.author().id)
         .await;
 
-    reply.edit(ctx, |b| b.components(|b| b)).await?; // remove buttons after button press
-    // NOTE: Can this be done in one .edit?
-    reply.edit(ctx, |b| b.content("Processing... Please wait.")).await?; // Edit message to processing after button press 
+    reply.edit(ctx, |b| b.components(|b| b).content("Processing... Please wait.")).await?; // remove buttons after button press and edit message
     let pressed_button_id = match &interaction {
         Some(m) => &m.data.custom_id,
         None => {

--- a/src/builtins/register.rs
+++ b/src/builtins/register.rs
@@ -188,6 +188,8 @@ pub async fn register_application_commands_buttons<U, E>(
         .await;
 
     reply.edit(ctx, |b| b.components(|b| b)).await?; // remove buttons after button press
+    // NOTE: Can this be done in one .edit?
+    reply.edit(ctx, |b| b.content("Processing... Please wait.")).await?; // Edit message to processing after button press 
     let pressed_button_id = match &interaction {
         Some(m) => &m.data.custom_id,
         None => {

--- a/src/builtins/register.rs
+++ b/src/builtins/register.rs
@@ -1,5 +1,4 @@
 //! Utilities for registering application commands
-
 use crate::serenity_prelude as serenity;
 
 /// Collects all commands into a [`serenity::CreateApplicationCommands`] builder, which can be used
@@ -209,6 +208,8 @@ pub async fn register_application_commands_buttons<U, E>(
         }
     };
 
+    let start_time = std::time::Instant::now();
+
     if global {
         if register {
             ctx.say(format!(":gear: Registering {} global commands...", num_commands))
@@ -247,6 +248,9 @@ pub async fn register_application_commands_buttons<U, E>(
         }
     }
 
-    ctx.say(":white_check_mark: Done!").await?;
+    // Calulate time taken and send message
+    let time_taken = start_time.elapsed();
+    ctx.say(format!(":white_check_mark: Done! Took {}ms", time_taken.as_millis())).await?;
+    
     Ok(())
 }

--- a/src/builtins/register.rs
+++ b/src/builtins/register.rs
@@ -187,11 +187,16 @@ pub async fn register_application_commands_buttons<U, E>(
         .author_id(ctx.author().id)
         .await;
 
-    reply.edit(ctx, |b| b.components(|b| b).content("Processing... Please wait.")).await?; // remove buttons after button press and edit message
+    reply
+        .edit(ctx, |b| {
+            b.components(|b| b).content("Processing... Please wait.")
+        })
+        .await?; // remove buttons after button press and edit message
     let pressed_button_id = match &interaction {
         Some(m) => &m.data.custom_id,
         None => {
-            ctx.say(":warning: You didn't interact in time - please run the command again.").await?;
+            ctx.say(":warning: You didn't interact in time - please run the command again.")
+                .await?;
             return Ok(());
         }
     };
@@ -211,8 +216,11 @@ pub async fn register_application_commands_buttons<U, E>(
 
     if global {
         if register {
-            ctx.say(format!(":gear: Registering {} global commands...", num_commands))
-                .await?;
+            ctx.say(format!(
+                ":gear: Registering {} global commands...",
+                num_commands
+            ))
+            .await?;
             serenity::Command::set_global_application_commands(ctx.discord(), |b| {
                 *b = create_commands;
                 b
@@ -231,8 +239,11 @@ pub async fn register_application_commands_buttons<U, E>(
             }
         };
         if register {
-            ctx.say(format!(":gear: Registering {} guild commands...", num_commands))
-                .await?;
+            ctx.say(format!(
+                ":gear: Registering {} guild commands...",
+                num_commands
+            ))
+            .await?;
             guild_id
                 .set_application_commands(ctx.discord(), |b| {
                     *b = create_commands;
@@ -249,7 +260,11 @@ pub async fn register_application_commands_buttons<U, E>(
 
     // Calulate time taken and send message
     let time_taken = start_time.elapsed();
-    ctx.say(format!(":white_check_mark: Done! Took {}ms", time_taken.as_millis())).await?;
-    
+    ctx.say(format!(
+        ":white_check_mark: Done! Took {}ms",
+        time_taken.as_millis()
+    ))
+    .await?;
+
     Ok(())
 }

--- a/src/builtins/register.rs
+++ b/src/builtins/register.rs
@@ -153,11 +153,13 @@ pub async fn register_application_commands_buttons<U, E>(
                             b.custom_id("register.guild")
                                 .label("Register in guild")
                                 .style(serenity::ButtonStyle::Primary)
+                                .emoji(serenity::ReactionType::Unicode("📋".to_string()))
                         })
                         .create_button(|b| {
                             b.custom_id("unregister.guild")
                                 .label("Delete in guild")
                                 .style(serenity::ButtonStyle::Danger)
+                                .emoji(serenity::ReactionType::Unicode("🗑️".to_string()))
                         })
                     })
                     .create_action_row(|r| {
@@ -165,11 +167,13 @@ pub async fn register_application_commands_buttons<U, E>(
                             b.custom_id("register.global")
                                 .label("Register globally")
                                 .style(serenity::ButtonStyle::Primary)
+                                .emoji(serenity::ReactionType::Unicode("📋".to_string()))
                         })
                         .create_button(|b| {
                             b.custom_id("unregister.global")
                                 .label("Delete globally")
                                 .style(serenity::ButtonStyle::Danger)
+                                .emoji(serenity::ReactionType::Unicode("🗑️".to_string()))
                         })
                     })
                 })
@@ -187,7 +191,7 @@ pub async fn register_application_commands_buttons<U, E>(
     let pressed_button_id = match &interaction {
         Some(m) => &m.data.custom_id,
         None => {
-            ctx.say("You didn't interact in time").await?;
+            ctx.say(":warning: You didn't interact in time - please run the command again.").await?;
             return Ok(());
         }
     };
@@ -205,7 +209,7 @@ pub async fn register_application_commands_buttons<U, E>(
 
     if global {
         if register {
-            ctx.say(format!("Registering {} global commands...", num_commands))
+            ctx.say(format!(":gear: Registering {} global commands...", num_commands))
                 .await?;
             serenity::Command::set_global_application_commands(ctx.discord(), |b| {
                 *b = create_commands;
@@ -213,19 +217,19 @@ pub async fn register_application_commands_buttons<U, E>(
             })
             .await?;
         } else {
-            ctx.say("Unregistering global commands...").await?;
+            ctx.say(":gear: Unregistering global commands...").await?;
             serenity::Command::set_global_application_commands(ctx.discord(), |b| b).await?;
         }
     } else {
         let guild_id = match ctx.guild_id() {
             Some(x) => x,
             None => {
-                ctx.say("Must be called in guild").await?;
+                ctx.say(":x: Must be called in guild").await?;
                 return Ok(());
             }
         };
         if register {
-            ctx.say(format!("Registering {} guild commands...", num_commands))
+            ctx.say(format!(":gear: Registering {} guild commands...", num_commands))
                 .await?;
             guild_id
                 .set_application_commands(ctx.discord(), |b| {
@@ -234,13 +238,13 @@ pub async fn register_application_commands_buttons<U, E>(
                 })
                 .await?;
         } else {
-            ctx.say("Unregistering guild commands...").await?;
+            ctx.say(":gear: Unregistering guild commands...").await?;
             guild_id
                 .set_application_commands(ctx.discord(), |b| b)
                 .await?;
         }
     }
 
-    ctx.say("Done!").await?;
+    ctx.say(":white_check_mark: Done!").await?;
     Ok(())
 }


### PR DESCRIPTION
In this PR, I add:

- All buttons now have emojis, 📋for register global/guild and 🗑️ for delete global/guild.
- Reworded the timeout message
- Add emojis to messages where it seemed appropriate. 
- Message also changes to a "processing" message.
- Adds a time took at the end

Screenshots:
![image](https://user-images.githubusercontent.com/5618953/197275642-baff5b5d-7cc7-4f70-a4ff-397fe9ca92bb.png)
![image](https://user-images.githubusercontent.com/5618953/197275619-21b66257-8767-4803-8acf-b3e156e4d84b.png)



