### PR TITLE
impl AsRef<Http>, AsRef<Cache> for Context

### DIFF
--- a/src/structs/context.rs
+++ b/src/structs/context.rs
@@ -440,6 +440,7 @@ impl<'a, U, E> AsRef<serenity::Http> for Context<'a, U, E> {
     }
 }
 
+#[cfg(feature = "cache")]
 impl<'a, U, E> AsRef<serenity::Cache> for Context<'a, U, E> {
     fn as_ref(&self) -> &serenity::Cache {
         &self.discord().cache
@@ -448,12 +449,13 @@ impl<'a, U, E> AsRef<serenity::Cache> for Context<'a, U, E> {
 
 impl<'a, U, E> serenity::CacheHttp for Context<'a, U, E>
 where
-    U: Send + Sync,
+    U: Sync,
 {
     fn http(&self) -> &serenity::Http {
         &self.discord().http
     }
 
+    #[cfg(feature = "cache")]
     fn cache(&self) -> Option<&std::sync::Arc<serenity::Cache>> {
         Some(&self.discord().cache)
     }

--- a/src/structs/context.rs
+++ b/src/structs/context.rs
@@ -445,3 +445,16 @@ impl<'a, U, E> AsRef<serenity::Cache> for Context<'a, U, E> {
         &self.discord().cache
     }
 }
+
+impl<'a, U, E> serenity::CacheHttp for Context<'a, U, E>
+where
+    U: Send + Sync,
+{
+    fn http(&self) -> &serenity::Http {
+        &self.discord().http
+    }
+
+    fn cache(&self) -> Option<&std::sync::Arc<serenity::Cache>> {
+        Some(&self.discord().cache)
+    }
+}

--- a/src/structs/context.rs
+++ b/src/structs/context.rs
@@ -433,3 +433,15 @@ impl<'a, U, E> From<Context<'a, U, E>> for PartialContext<'a, U, E> {
         }
     }
 }
+
+impl<'a, U, E> AsRef<serenity::Http> for Context<'a, U, E> {
+    fn as_ref(&self) -> &serenity::Http {
+        &self.discord().http
+    }
+}
+
+impl<'a, U, E> AsRef<serenity::Cache> for Context<'a, U, E> {
+    fn as_ref(&self) -> &serenity::Cache {
+        &self.discord().cache
+    }
+}


### PR DESCRIPTION
No need to use `ctx.discord()` everywhere now