### PR TITLE
Allow AutocompleteChoice<T> to only require T impl Serialize rather than From<T>

### DIFF
--- a/macros/src/command/slash.rs
+++ b/macros/src/command/slash.rs
@@ -51,7 +51,7 @@ pub fn generate_parameters(inv: &Invocation) -> Result<Vec<proc_macro2::TokenStr
                         // AutocompleteChoice<T> -> serde_json::Value
                         .map(|choice| poise::serenity_prelude::json::json!({
                             "name": choice.name,
-                            "value": poise::serenity_prelude::json::Value::from(choice.value),
+                            "value": choice.value,
                         }))
                         .collect()
                         .await;


### PR DESCRIPTION
This can be done by using `json::to_value()` which is what the `json!()` macro does.