### PR TITLE
[Feature] Allow to bypass command checks for owners

### DIFF
--- a/examples/framework_usage/main.rs
+++ b/examples/framework_usage/main.rs
@@ -134,6 +134,9 @@ async fn main() {
                 Ok(true)
             })
         }),
+        /// Enforce command checks even for owners (enforced by default)
+        /// Set to true to bypass checks, which is useful for testing
+        skip_checks_for_owners: false,
         event_handler: |_ctx, event, _framework, _data| {
             Box::pin(async move {
                 println!("Got an event in event handler: {:?}", event.name());

--- a/src/dispatch/common.rs
+++ b/src/dispatch/common.rs
@@ -77,6 +77,11 @@ async fn check_permissions_and_cooldown_single<'a, U, E>(
     ctx: crate::Context<'a, U, E>,
     cmd: &'a crate::Command<U, E>,
 ) -> Result<(), crate::FrameworkError<'a, U, E>> {
+    // Skip command checks if `FrameworkOptions::skip_checks_for_owners` is set to true
+    if ctx.framework().options.skip_checks_for_owners {
+        return Ok(());
+    }
+
     if cmd.owners_only && !ctx.framework().options().owners.contains(&ctx.author().id) {
         return Err(crate::FrameworkError::NotAnOwner { ctx });
     }
@@ -148,12 +153,8 @@ async fn check_permissions_and_cooldown_single<'a, U, E>(
         None => {}
     }
 
-    // Only continue if command checks returns true or
-    // `FrameworkOptions::skip_checks_for_owners` is set to true
+    // Only continue if command checks returns true
     // First perform global checks, then command checks (if necessary)
-    if ctx.framework().options.skip_checks_for_owners {
-        return Ok(());
-    }
     for check in Option::iter(&ctx.framework().options().command_check).chain(&cmd.checks) {
         match check(ctx).await {
             Ok(true) => {}

--- a/src/dispatch/common.rs
+++ b/src/dispatch/common.rs
@@ -78,7 +78,9 @@ async fn check_permissions_and_cooldown_single<'a, U, E>(
     cmd: &'a crate::Command<U, E>,
 ) -> Result<(), crate::FrameworkError<'a, U, E>> {
     // Skip command checks if `FrameworkOptions::skip_checks_for_owners` is set to true
-    if ctx.framework().options.skip_checks_for_owners {
+    if ctx.framework().options.skip_checks_for_owners
+        && ctx.framework().options().owners.contains(&ctx.author().id)
+    {
         return Ok(());
     }
 

--- a/src/dispatch/common.rs
+++ b/src/dispatch/common.rs
@@ -148,8 +148,12 @@ async fn check_permissions_and_cooldown_single<'a, U, E>(
         None => {}
     }
 
-    // Only continue if command checks returns true. First perform global checks, then command
-    // checks (if necessary)
+    // Only continue if command checks returns true or
+    // `FrameworkOptions::skip_checks_for_owners` is set to true
+    // First perform global checks, then command checks (if necessary)
+    if ctx.framework().options.skip_checks_for_owners {
+        return Ok(());
+    }
     for check in Option::iter(&ctx.framework().options().command_check).chain(&cmd.checks) {
         match check(ctx).await {
             Ok(true) => {}

--- a/src/structs/framework_options.rs
+++ b/src/structs/framework_options.rs
@@ -23,6 +23,8 @@ pub struct FrameworkOptions<U, E> {
     /// If individual commands add their own check, both callbacks are run and must return true.
     #[derivative(Debug = "ignore")]
     pub command_check: Option<fn(crate::Context<'_, U, E>) -> BoxFuture<'_, Result<bool, E>>>,
+    /// If set to true, skips command checks if command was issued by [`FrameworkOptions::owners`]
+    pub skip_checks_for_owners: bool,
     /// Default set of allowed mentions to use for all responses
     ///
     /// By default, user pings are allowed and role pings and everyone pings are filtered
@@ -101,6 +103,7 @@ where
             pre_command: |_| Box::pin(async {}),
             post_command: |_| Box::pin(async {}),
             command_check: None,
+            skip_checks_for_owners: false,
             allowed_mentions: Some({
                 let mut f = serenity::CreateAllowedMentions::default();
                 // Only support direct user pings by default


### PR DESCRIPTION
This feature introduces a new option in FrameworkOptions called skip_checks_for_owners which allows owners to skip command dispatch checks to bypass permission checks.

 Added usage documentation in [framework_usage](https://github.com/peanutbother/poise/pull/examples/framework_usage/main.rs).