### PR TITLE
Fix FrameworkContext::user_data being async

### DIFF
--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -166,6 +166,7 @@ pub async fn on_error<U, E: std::fmt::Display + std::fmt::Debug>(
 /// An autocomplete function that can be used for the command parameter in your help function.
 ///
 /// See `examples/framework_usage` for an example
+#[allow(clippy::unused_async)] // Required for the return type
 pub async fn autocomplete_command<'a, U, E>(
     ctx: crate::Context<'a, U, E>,
     partial: &'a str,

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -43,7 +43,7 @@ impl<'a, U, E> FrameworkContext<'a, U, E> {
     }
 
     /// Retrieves user data
-    pub async fn user_data(&self) -> &'a U {
+    pub fn user_data(&self) -> &'a U {
         self.user_data
     }
 }
@@ -161,7 +161,7 @@ pub async fn dispatch_event<U: Send + Sync, E>(
     // Do this after the framework's Ready handling, so that get_user_data() doesnt
     // potentially block infinitely
     if let Err(error) =
-        (framework.options.event_handler)(ctx, event, framework, framework.user_data().await).await
+        (framework.options.event_handler)(ctx, event, framework, framework.user_data()).await
     {
         let error = crate::FrameworkError::EventHandler {
             ctx,

--- a/src/dispatch/prefix.rs
+++ b/src/dispatch/prefix.rs
@@ -16,7 +16,7 @@ async fn strip_prefix<'a, U, E>(
         author: &msg.author,
         serenity_context: ctx,
         framework,
-        data: framework.user_data().await,
+        data: framework.user_data(),
     };
 
     if let Some(dynamic_prefix) = framework.options.prefix_options.dynamic_prefix {
@@ -66,7 +66,7 @@ async fn strip_prefix<'a, U, E>(
     }
 
     if let Some(dynamic_prefix) = framework.options.prefix_options.stripped_dynamic_prefix {
-        match dynamic_prefix(ctx, msg, framework.user_data().await).await {
+        match dynamic_prefix(ctx, msg, framework.user_data()).await {
             Ok(result) => {
                 if let Some((prefix, content)) = result {
                     return Some((prefix, content));
@@ -264,7 +264,7 @@ pub async fn parse_invocation<'a, U: Send + Sync, E>(
         invoked_command_name,
         args,
         framework,
-        data: framework.user_data().await,
+        data: framework.user_data(),
         parent_commands,
         command,
         invocation_data,

--- a/src/dispatch/slash.rs
+++ b/src/dispatch/slash.rs
@@ -55,7 +55,7 @@ pub async fn extract_command_and_run_checks<'a, U, E>(
         })?;
 
     let ctx = crate::ApplicationContext {
-        data: framework.user_data().await,
+        data: framework.user_data(),
         serenity_context: ctx,
         framework,
         interaction,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
     clippy::missing_docs_in_private_items,
     clippy::unused_async,
     rust_2018_idioms,
-    missing_docs,
+    missing_docs
 )]
 /*!
 Poise is an opinionated Discord bot framework with a few distinctive features:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
 #![cfg_attr(doc_nightly, feature(doc_cfg, doc_auto_cfg))]
 #![doc(test(attr(deny(deprecated))))]
-#![warn(rust_2018_idioms)]
-#![warn(missing_docs)]
-#![warn(clippy::missing_docs_in_private_items)]
-#![allow(clippy::type_complexity)]
 // native #[non_exhaustive] is awful because you can't do struct update syntax with it (??)
 #![allow(clippy::manual_non_exhaustive)]
-
+#![allow(clippy::type_complexity)]
+#![warn(
+    clippy::missing_docs_in_private_items,
+    clippy::unused_async,
+    rust_2018_idioms,
+    missing_docs,
+)]
 /*!
 Poise is an opinionated Discord bot framework with a few distinctive features:
 - edit tracking: when user edits their message, automatically update bot response


### PR DESCRIPTION
<!-- please base the PR on the develop branch if possible 😇 -->
`FrameworkContext::user_data` wasn't awaiting anything, as it already has a reference to the user data. This also adds the lint `clippy::unused_async`, part of the allowed pedantic group, to the warning lints to prevent this happening again.