### PR TITLE
Add missing commas in macros for localizations

### DIFF
--- a/examples/framework_usage/commands/localization.rs
+++ b/examples/framework_usage/commands/localization.rs
@@ -9,18 +9,28 @@ pub enum WelcomeChoice {
         "de",
         "Willkommen auf unserem coolen Server! Frag mich, falls du Hilfe brauchst"
     )]
+    #[name_localized(
+        "es",
+        "¡Bienvenido a nuestro genial servidor! Pregúntame si necesitas ayuda"
+    )]
     A,
     #[name = "Welcome to the club, you're now a good person. Well, I hope."]
     #[name_localized(
         "de",
         "Willkommen im Club, du bist jetzt ein guter Mensch. Naja, hoffentlich."
     )]
+    #[name_localized(
+        "es",
+        "Bienvenido al club, ahora eres una buena persona. Bueno, eso espero."
+    )]
     B,
     #[name = "I hope that you brought a controller to play together!"]
     #[name_localized("de", "Ich hoffe du hast einen Controller zum Spielen mitgebracht!")]
+    #[name_localized("es", "Espero que hayas traído un mando para jugar juntos.")]
     C,
     #[name = "Hey, do you want a coffee?"]
     #[name_localized("de", "Hey, willst du einen Kaffee?")]
+    #[name_localized("es", "Oye, ¿Quieres un café?")]
     D,
 }
 
@@ -28,16 +38,22 @@ pub enum WelcomeChoice {
 #[poise::command(
     slash_command,
     name_localized("de", "begrüßen"),
-    description_localized("de", "Einen Nutzer begrüßen")
+    name_localized("es", "saludar"),
+    description_localized("de", "Einen Nutzer begrüßen"),
+    description_localized("es", "Saludar a un usuario")
 )]
 pub async fn welcome(
     ctx: Context<'_>,
     #[name_localized("de", "nutzer")]
     #[description_localized("de", "Der zu begrüßende Nutzer")]
+    #[name_localized("es", "usuario")]
+    #[description_localized("es", "El usuario a saludar")]
     #[description = "The user to welcome"]
     user: serenity::User,
     #[name_localized("de", "nachricht")]
     #[description_localized("de", "Die versendete Nachricht")]
+    #[name_localized("es", "mensaje")]
+    #[description_localized("es", "El mensaje enviado")]
     #[description = "The message to send"]
     message: WelcomeChoice,
 ) -> Result<(), Error> {

--- a/macros/src/choice_parameter.rs
+++ b/macros/src/choice_parameter.rs
@@ -94,7 +94,7 @@ pub fn choice_parameter(input: syn::DeriveInput) -> Result<TokenStream, darling:
                 vec![ #( poise::CommandParameterChoice {
                     name: #names.to_string(),
                     localizations: std::collections::HashMap::from([
-                        #( (#locales.to_string(), #localized_names.to_string()) )*
+                        #( (#locales.to_string(), #localized_names.to_string()) ),*
                     ]),
                 }, )* ]
             }

--- a/macros/src/command/slash.rs
+++ b/macros/src/command/slash.rs
@@ -99,11 +99,11 @@ pub fn generate_parameters(inv: &Invocation) -> Result<Vec<proc_macro2::TokenStr
                 ::poise::CommandParameter {
                     name: #param_name.to_string(),
                     name_localizations: vec![
-                        #( (#name_locales.to_string(), #name_localized_values.to_string()) )*
+                        #( (#name_locales.to_string(), #name_localized_values.to_string()) ),*
                     ].into_iter().collect(),
                     description: #description,
                     description_localizations: vec![
-                        #( (#description_locales.to_string(), #description_localized_values.to_string()) )*
+                        #( (#description_locales.to_string(), #description_localized_values.to_string()) ),*
                     ].into_iter().collect(),
                     required: #required,
                     channel_types: #channel_types,

--- a/macros/src/util.rs
+++ b/macros/src/util.rs
@@ -75,7 +75,7 @@ pub fn vec_tuple_2_to_hash_map(v: Vec<Tuple2<String>>) -> proc_macro2::TokenStre
     let (keys, values): (Vec<String>, Vec<String>) = v.into_iter().map(|x| (x.0, x.1)).unzip();
     quote::quote! {
         std::collections::HashMap::from([
-            #( (#keys.to_string(), #values.to_string()) )*
+            #( (#keys.to_string(), #values.to_string()) ),*
         ])
     }
 }


### PR DESCRIPTION
When you provide multiple localized names / descriptions the macros generate code like `vec![ ("foo", "bar") ("baz", "qux") ]`.
This PR adds the missing commas between the HashMap / Vec elements.