### PR TITLE
Add missing events to EventWrapper

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -78,6 +78,11 @@ macro_rules! event {
 // with help from vscode multiline editing and some manual cleanup
 event! {
     'a
+    application_command_permissions_update => ApplicationCommandPermissionsUpdate { permission: serenity::CommandPermission },
+    auto_moderation_action_execution => AutoModerationActionExecution { execution: serenity::ActionExecution },
+    auto_moderation_rule_create => AutoModerationRuleCreate{ rule: serenity::Rule },
+    auto_moderation_rule_update => AutoModerationRuleUpdate{ rule: serenity::Rule },
+    auto_moderation_rule_delete => AutoModerationRuleDelete{ rule: serenity::Rule },
     #[cfg(feature = "cache")]
     cache_ready => CacheReady { guilds: Vec<serenity::GuildId> },
     channel_create<'a> => ChannelCreate { channel: &'a serenity::GuildChannel },
@@ -120,6 +125,11 @@ event! {
     guild_role_update => GuildRoleUpdate { old_data_if_available: Option<serenity::Role>, new: serenity::Role },
     #[cfg(not(feature = "cache"))]
     guild_role_update => GuildRoleUpdate { new: serenity::Role },
+    guild_scheduled_event_create => GuildScheduledEventCreate { event: serenity::ScheduledEvent },
+    guild_scheduled_event_update => GuildScheduledEventUpdate { event: serenity::ScheduledEvent },
+    guild_scheduled_event_delete => GuildScheduledEventDelete { event: serenity::ScheduledEvent },
+    guild_scheduled_event_user_add => GuildScheduledEventUserAdd { subscribed: serenity::GuildScheduledEventUserAddEvent },
+    guild_scheduled_event_user_remove => GuildScheduledEventUserRemove { unsubscribed: serenity::GuildScheduledEventUserRemoveEvent },
     guild_stickers_update => GuildStickersUpdate { guild_id: serenity::GuildId, current_state: std::collections::HashMap<serenity::StickerId, serenity::Sticker>},
     guild_unavailable => GuildUnavailable { guild_id: serenity::GuildId },
     #[cfg(feature = "cache")]
@@ -129,6 +139,7 @@ event! {
     integration_create => IntegrationCreate { integration: serenity::Integration },
     integration_update => IntegrationUpdate { integration: serenity::Integration },
     integration_delete => IntegrationDelete { integration_id: serenity::IntegrationId, guild_id: serenity::GuildId, application_id: Option<serenity::ApplicationId> },
+    interaction_create => InteractionCreate { interaction: serenity::Interaction },
     invite_create => InviteCreate { data: serenity::InviteCreateEvent },
     invite_delete => InviteDelete { data: serenity::InviteDeleteEvent },
     message => Message { new_message: serenity::Message },
@@ -167,5 +178,4 @@ event! {
     #[cfg(not(feature = "cache"))]
     voice_state_update => VoiceStateUpdate { new: serenity::VoiceState },
     webhook_update => WebhookUpdate { guild_id: serenity::GuildId, belongs_to_channel_id: serenity::ChannelId },
-    interaction_create => InteractionCreate { interaction: serenity::Interaction },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,6 +390,7 @@ pub mod serenity_prelude {
                 },
             },
             event::*,
+            guild::automod::*,
             prelude::*,
         },
         prelude::*,


### PR DESCRIPTION
I noticed a few events were present in [serenity](https://docs.rs/serenity/0.11.5/serenity/index.html)::[client](https://docs.rs/serenity/0.11.5/serenity/client/index.html)::[EventHandler](https://docs.rs/serenity/0.11.5/serenity/client/trait.EventHandler.html#) but missing from [poise](https://docs.rs/poise/latest/poise/index.html)::[event](https://docs.rs/poise/latest/poise/event/index.html)::[EventWrapper](https://docs.rs/poise/latest/poise/event/struct.EventWrapper.html#), so I added them. I was able to test that the GuildScheduledEvent events work properly, the others haven't been tested explicitly. I didn't see any unit tests to update, but if I missed them let me know and I'll add some tests.

The events added are:

* `ApplicationCommandPermissionsUpdate` 
* `AutoModerationActionExecution` 
* `AutoModerationRuleCreate`
* `AutoModerationRuleUpdate`
* `AutoModerationRuleDelete`
* `GuildScheduledEventCreate` 
* `GuildScheduledEventUpdate` 
* `GuildScheduledEventDelete` 
* `GuildScheduledEventUserAdd` 
* `GuildScheduledEventUserRemove` 

Incidentally, I also moved the `InteractionCreate` event into alphabetical order, and `pub use`d the `serenity::model::guild::automod::*` structs inline with the other event argument types.