### PR TITLE
Add CooldownContext struct to make Cooldowns usable in more situations

### DIFF
--- a/macros/src/command/prefix.rs
+++ b/macros/src/command/prefix.rs
@@ -78,7 +78,7 @@ pub fn generate_prefix_action(inv: &Invocation) -> Result<proc_macro2::TokenStre
             ))?;
 
             if !ctx.framework.options.manual_cooldowns {
-                ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.into());
+                ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());
             }
 
             inner(ctx.into(), #( #param_names, )* )

--- a/macros/src/command/slash.rs
+++ b/macros/src/command/slash.rs
@@ -191,7 +191,7 @@ pub fn generate_slash_action(inv: &Invocation) -> Result<proc_macro2::TokenStrea
             })?;
 
             if !ctx.framework.options.manual_cooldowns {
-                ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.into());
+                ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());
             }
 
             inner(ctx.into(), #( #param_identifiers, )*)
@@ -221,7 +221,7 @@ pub fn generate_context_menu_action(
         <#param_type as ::poise::ContextMenuParameter<_, _>>::to_action(|ctx, value| {
             Box::pin(async move {
                 if !ctx.framework.options.manual_cooldowns {
-                    ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.into());
+                    ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());
                 }
 
                 inner(ctx.into(), value)

--- a/src/dispatch/common.rs
+++ b/src/dispatch/common.rs
@@ -159,7 +159,10 @@ async fn check_permissions_and_cooldown_single<'a, U, E>(
 
     if !ctx.framework().options().manual_cooldowns {
         let cooldowns = &cmd.cooldowns;
-        let remaining_cooldown = cooldowns.lock().unwrap().remaining_cooldown(ctx);
+        let remaining_cooldown = cooldowns
+            .lock()
+            .unwrap()
+            .remaining_cooldown(ctx.cooldown_context());
         if let Some(remaining_cooldown) = remaining_cooldown {
             return Err(crate::FrameworkError::CooldownHit {
                 ctx,

--- a/src/prefix_argument/code_block.rs
+++ b/src/prefix_argument/code_block.rs
@@ -57,7 +57,7 @@ fn pop_from(args: &str) -> Result<(&str, CodeBlock), CodeBlockError> {
 
     let rest;
     let mut code_block = if let Some(code_block) = args.strip_prefix("```") {
-        let code_block_end = code_block.find("```").ok_or(CodeBlockError::default())?;
+        let code_block_end = code_block.find("```").ok_or_else(CodeBlockError::default)?;
         rest = &code_block[(code_block_end + 3)..];
         let mut code_block = &code_block[..code_block_end];
 
@@ -85,7 +85,7 @@ fn pop_from(args: &str) -> Result<(&str, CodeBlock), CodeBlockError> {
             __non_exhaustive: (),
         }
     } else if let Some(code_line) = args.strip_prefix('`') {
-        let code_line_end = code_line.find('`').ok_or(CodeBlockError::default())?;
+        let code_line_end = code_line.find('`').ok_or_else(CodeBlockError::default)?;
         rest = &code_line[(code_line_end + 1)..];
         let code_line = &code_line[..code_line_end];
 

--- a/src/structs/context.rs
+++ b/src/structs/context.rs
@@ -154,6 +154,16 @@ context_methods! {
         }
     }
 
+    /// Create a [`crate::CooldownContext`] based off the underlying context type.
+    (cooldown_context self)
+    (pub fn cooldown_context(self) -> crate::CooldownContext) {
+        crate::CooldownContext {
+            user_id: self.author().id,
+            channel_id: self.channel_id(),
+            guild_id: self.guild_id()
+        }
+    }
+
     /// See [`Self::serenity_context`].
     #[deprecated = "poise::Context can now be passed directly into most serenity functions. Otherwise, use `.serenity_context()` now"]
     #[allow(deprecated)]


### PR DESCRIPTION
### Problem
I was wanting to implement cooldowns in some custom event handler, but unfortunately it is not practical to construct a `poise::Context` manually which is required to use the `Cooldowns` struct.

### Proposal
This PR refactors `Cooldowns` slightly to add an extra layer of abstraction around the `poise::Context` to make `Cooldowns` easier to use outside of a prefix/application command.
