### PR TITLE
Convert Cooldowns to use HashMap instead of OrderedMap for better scaling

### DIFF
--- a/src/cooldown.rs
+++ b/src/cooldown.rs
@@ -2,7 +2,7 @@
 
 use crate::serenity_prelude as serenity;
 // I usually don't really do imports, but these are very convenient
-use crate::util::OrderedMap;
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 /// Subset of [`crate::Context`] so that [`Cooldowns`] can be used without requiring a full [Context](`crate::Context`)
@@ -38,7 +38,7 @@ pub struct CooldownConfig {
 ///
 /// You probably don't need to use this directly. `#[poise::command]` automatically generates a
 /// cooldown handler.
-#[derive(Default, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct Cooldowns {
     /// Stores the cooldown durations
     cooldown: CooldownConfig,
@@ -46,13 +46,13 @@ pub struct Cooldowns {
     /// Stores the timestamp of the last global invocation
     global_invocation: Option<Instant>,
     /// Stores the timestamps of the last invocation per user
-    user_invocations: OrderedMap<serenity::UserId, Instant>,
+    user_invocations: HashMap<serenity::UserId, Instant>,
     /// Stores the timestamps of the last invocation per guild
-    guild_invocations: OrderedMap<serenity::GuildId, Instant>,
+    guild_invocations: HashMap<serenity::GuildId, Instant>,
     /// Stores the timestamps of the last invocation per channel
-    channel_invocations: OrderedMap<serenity::ChannelId, Instant>,
+    channel_invocations: HashMap<serenity::ChannelId, Instant>,
     /// Stores the timestamps of the last invocation per member (user and guild)
-    member_invocations: OrderedMap<(serenity::UserId, serenity::GuildId), Instant>,
+    member_invocations: HashMap<(serenity::UserId, serenity::GuildId), Instant>,
 }
 
 impl Cooldowns {
@@ -62,10 +62,10 @@ impl Cooldowns {
             cooldown: config,
 
             global_invocation: None,
-            user_invocations: OrderedMap::new(),
-            guild_invocations: OrderedMap::new(),
-            channel_invocations: OrderedMap::new(),
-            member_invocations: OrderedMap::new(),
+            user_invocations: HashMap::new(),
+            guild_invocations: HashMap::new(),
+            channel_invocations: HashMap::new(),
+            member_invocations: HashMap::new(),
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,6 +17,7 @@ impl<K: Eq, V> OrderedMap<K, V> {
     }
 
     /// Finds a value in the map by the given key
+    #[allow(dead_code)]
     pub fn get(&self, k: &K) -> Option<&V> {
         self.0
             .iter()
@@ -25,6 +26,7 @@ impl<K: Eq, V> OrderedMap<K, V> {
     }
 
     /// Inserts a key value pair into the map
+    #[allow(dead_code)]
     pub fn insert(&mut self, k: K, v: V) {
         match self.0.iter_mut().find(|entry| entry.0 == k) {
             Some(entry) => entry.1 = v,


### PR DESCRIPTION
Follow-up from discussion in #175:

I have replaced the `OrderedMap` with `HashMap` in `Cooldowns` and everything seems to be fine (all tests pass and no issues in some simple tests with my WIP bot). 

I did have to remove `#[derive(Hash)]` from `Cooldowns` as `HashMap` does not implement `Hash`, however it seems weird that you would ever want the hash of a `Cooldowns` object since that would be highly volatile depending on the state of the cooldowns. If we think it's important to preserve the `Hash` impl on `Cooldowns`, I would suggest we a `BTreeMap` instead of the `OrderedMap` since we never iterate through the entire map and lookups/inserts will be much more performant on a `BTreeMap` at scale.

This also leaves `OrderedMap` with only one use-case which just uses `get_or_insert_with` and `into_iter()`. This meant I had to add `#[allow(dead_code)]` to `get` and `insert` of `OrderedMap` since those aren't used anymore. We could just delete the functions but I didn't want to do that since IMO it would be weird to have a `*Map` type with only a special insert and iterate. The other option would be to just remove `OrderedMap` entirely and use a `BTreeMap` in places where order matters and `HashMap`s elsewhere, but I don't see any issue with keeping the `OrderedMap` for the help use-case since order does matter and the map is probably small enough that it doesn't matter (probably even large cases will have <100 commands).
https://github.com/serenity-rs/poise/blob/6cc521a9b0398384c2be15ef4a5d8d1b9e52364a/src/builtins/help.rs#L293-L298 
https://github.com/serenity-rs/poise/blob/6cc521a9b0398384c2be15ef4a5d8d1b9e52364a/src/builtins/help.rs#L305