### PR TITLE
Fix failing CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,12 @@ jobs:
           - name: no features
             # don't test examples because they need collector feature
             command: cargo test --no-default-features --features serenity/rustls_backend --lib --tests
-          
-          - name: all features + simdjson
-            command: cargo test --all-features --features serenity/simdjson --lib --tests --examples
-            rustflags: -C target-cpu=haswell # needed for simdjson
+
+          # TODO serentity/simdjson is broken. Re-enable once fixed upstream
+          # https://github.com/serenity-rs/serenity/issues/2474
+#          - name: all features + simdjson
+#            command: cargo test --all-features --features serenity/simdjson --lib --tests --examples
+#            rustflags: -C target-cpu=haswell # needed for simdjson
 
           - name: native TLS
             command: cargo test --all-features --features serenity/native_tls_backend --lib --tests --examples

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,9 +884,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -1134,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "serenity"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fd5e7b5858ad96e99d440138f34f5b98e1b959ebcd3a1036203b30e78eb788"
+checksum = "d007dc45584ecc47e791f2a9a7cf17bf98ac386728106f111159c846d624be3f"
 dependencies = [
  "async-trait",
  "async-tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ parking_lot = "0.12.1"
 [dependencies.serenity]
 default-features = false
 features = ["builder", "client", "gateway", "model", "utils", "collector"]
-version = "0.11.5"
+version = "0.11.6"
 
 [dev-dependencies]
 # For the examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,6 +430,7 @@ pub mod serenity_prelude {
         async_trait,
         builder::*,
         client::{
+            self, // Resolve ambiguous re-export
             bridge::gateway::{event::*, *},
             *,
         },
@@ -445,6 +446,13 @@ pub mod serenity_prelude {
             // There's two MessageFlags in serenity. The interaction response specific one was
             // renamed to InteractionResponseFlags above so we can keep this one's name the same
             channel::MessageFlags,
+            // Disambiguate several types/modules where names are re-used within serenity
+            // In general, we prefer the model types as they are more relevant when using poise
+            error,
+            event::{self, EventType},
+            gateway,
+            guild::automod::Action,
+            prelude,
         },
         model::{
             application::{


### PR DESCRIPTION
- Update serenity 0.11.5 -> 0.11.6
- Update proc_macro2 1.0.47 -> 1.0.64
- Disambiguate several serenity re-exports
- Temporarily disable serenity/simdjson test since feature is broken upstream (serenity-rs/serenity#2474)

<!-- base the PR on the current branch, if it has no breaking changes, and on the next branch, if it does -->
