### PR TITLE
Fix modal acknowledgement

### DIFF
--- a/src/modal.rs
+++ b/src/modal.rs
@@ -65,7 +65,7 @@ async fn execute_modal_generic<
     // Send acknowledgement so that the pop-up is closed
     response
         .create_interaction_response(ctx, |b| {
-            b.kind(serenity::InteractionResponseType::DeferredUpdateMessage)
+            b.kind(serenity::InteractionResponseType::DeferredChannelMessageWithSource)
         })
         .await?;
 

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -66,6 +66,7 @@ async fn execute_modal_generic<
     response
         .create_interaction_response(ctx, |b| {
             b.kind(serenity::InteractionResponseType::DeferredChannelMessageWithSource)
+                .interaction_response_data(|d| d.ephemeral(true))
         })
         .await?;
 


### PR DESCRIPTION
Discord has ceased accepting the `DeferredUpdateMessage` response type for acknowledging a modal, which has resulted in errors propping up when using modals via poise.

This fixes said errors by switching to the alternative `DeferredChannelMessageWithSource` type. In addition, the response to the modal is made ephemeral to prevent a "<Bot> is thinking..." message from appearing, waiting to be replaced by proper message content, which will never happen.