### PR TITLE
Revert "Fix modal acknowledgement (#200)"

### DIFF
--- a/src/modal.rs
+++ b/src/modal.rs
@@ -65,8 +65,7 @@ async fn execute_modal_generic<
     // Send acknowledgement so that the pop-up is closed
     response
         .create_interaction_response(ctx, |b| {
-            b.kind(serenity::InteractionResponseType::DeferredChannelMessageWithSource)
-                .interaction_response_data(|d| d.ephemeral(true))
+            b.kind(serenity::InteractionResponseType::DeferredUpdateMessage)
         })
         .await?;
 


### PR DESCRIPTION
This reverts commit 6d878bf2696c31ae8eaa639cff60d6b56f096f88.

The issue with being unable to acknowledge modal submits with `DeferredUpdateMessage` was temporary and now works again.
