### PR TITLE
Add ignore_thread_creation to PrefixFrameworkOptions

### DIFF
--- a/src/dispatch/prefix.rs
+++ b/src/dispatch/prefix.rs
@@ -234,6 +234,13 @@ pub async fn parse_invocation<'a, U: Send + Sync, E>(
         return Ok(None);
     }
 
+    // Check if we can execute commands contained in thread creation messages
+    if msg.kind == serenity::channel::MessageType::ThreadCreated
+        && framework.options.prefix_options.ignore_thread_creation
+    {
+        return Ok(None);
+    }
+
     // Strip prefix, trim whitespace between prefix and rest, split rest into command name and args
     let (prefix, msg_content) = match strip_prefix(framework, ctx, msg).await {
         Some(x) => x,

--- a/src/structs/prefix.rs
+++ b/src/structs/prefix.rs
@@ -144,6 +144,8 @@ pub struct PrefixFrameworkOptions<U, E> {
     pub execute_self_messages: bool,
     /// Whether to ignore messages from bots for command invoking. Default `true`
     pub ignore_bots: bool,
+    /// Whether to ignore commands contained within thread creation messages. Default `true`
+    pub ignore_thread_creation: bool,
     /// Whether command names should be compared case-insensitively.
     pub case_insensitive_commands: bool,
     /* // TODO: implement
@@ -173,6 +175,7 @@ impl<U, E> Default for PrefixFrameworkOptions<U, E> {
             ignore_edits_if_not_yet_responded: false,
             execute_self_messages: false,
             ignore_bots: true,
+            ignore_thread_creation: true,
             case_insensitive_commands: true,
             // help_when_mentioned: true,
             // help_commmand: None,


### PR DESCRIPTION
When a new thread is created the title can be parsed as if it were a prefix command invocation from a regular message, this adds an option to `PrefixFrameworkOptions` to ignore these accidental command invocations by default while preserving old behaviour if desired.