### PR TITLE
ci: start building docs for serenity-next

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,16 +103,15 @@ jobs:
           RUSTFLAGS: -C target-cpu=haswell # for simd-json
           RUSTDOCFLAGS: --cfg doc_nightly -D warnings
       
-      # If on current/next branch (as opposed to PR or whatever), publish docs to github pages
+      # If on current/next/serenity-next branch (as opposed to PR or whatever), publish docs to github pages
       - name: Move files
-        if: github.ref == 'refs/heads/current' || github.ref == 'refs/heads/next'
+        if: github.ref_name == 'current' || github.ref_name == 'next' || github.ref_name == 'serenity-next'
         shell: bash
         run: |
-          DIR=${GITHUB_REF#refs/heads/}
-          mkdir -p ./docs/$DIR
-          mv ./target/doc/* ./docs/$DIR/
+          mkdir -p ./docs/${{ github.ref_name }}
+          mv ./target/doc/* ./docs/${{ github.ref_name }}/
       - name: Deploy docs
-        if: github.ref == 'refs/heads/current' || github.ref == 'refs/heads/next'
+        if: github.ref_name == 'current' || github.ref_name == 'next' || github.ref_name == 'serenity-next'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should start building `serenity-next` docs on CI after it has been rebased to `serenity-next`.

I have also replaced `github.ref` with `github.ref_name` (see [github docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)). The change has been tested on a local fork of poise, as well as in my personal project (see [ci.yml](https://github.com/ev3nvy/rman-rs/blob/afa6c9d06830bb5210c738f3484551fea25cfe25/.github/workflows/ci.yml#L143) and [publish.yml](https://github.com/ev3nvy/rman-rs/blob/afa6c9d06830bb5210c738f3484551fea25cfe25/.github/workflows/publish.yml#L62)). There is also this [stackoverflow answer](https://stackoverflow.com/a/71642915).

TODO: add redirect `index.html` to `gh-pages/serenity-next`.