### PR TITLE
Prevent underscore binding lint

### DIFF
--- a/macros/src/command/prefix.rs
+++ b/macros/src/command/prefix.rs
@@ -52,6 +52,7 @@ pub fn generate_prefix_action(inv: &Invocation) -> Result<proc_macro2::TokenStre
     };
 
     Ok(quote::quote! {
+        #[allow(clippy::used_underscore_binding)]
         |ctx| Box::pin(async move {
             let ( #( #param_idents, )* .. ) = ::poise::parse_prefix_args!(
                 ctx.serenity_context, ctx.msg, ctx.args, 0 =>


### PR DESCRIPTION
This lint is triggered when we have an unused parameter in the handler function. The code that's generated copies the identifier name from the function definition, but does use the identifier, so we need to disable this lint. That said, a better solution might be to add a fixed prefix like `poise_arg_` to each parameter name.
