### PR TITLE
feat: implement generics commands

### DIFF
--- a/examples/generic_commands/main.rs
+++ b/examples/generic_commands/main.rs
@@ -1,0 +1,23 @@
+//! If you need it, poise-annotated command functions can also be generic over the user data type
+//! or error type
+//!
+//! The original use case for this feature was to have the same command in two different bots
+
+#[poise::command(slash_command)]
+pub async fn example<U: Sync, E>(ctx: poise::Context<'_, U, E>) -> Result<(), E> {
+    ctx.say(format!(
+        "My user data type is {} and the error type is {}",
+        std::any::type_name::<U>(),
+        std::any::type_name::<E>()
+    ))
+    .await
+    .unwrap();
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    let _example1 = example::<(), ()>();
+    let _example2 = example::<String, Box<dyn std::error::Error>>();
+}

--- a/macros/src/command/mod.rs
+++ b/macros/src/command/mod.rs
@@ -314,11 +314,12 @@ fn generate_command(mut inv: Invocation) -> Result<proc_macro2::TokenStream, dar
         crate::util::vec_tuple_2_to_hash_map(inv.args.description_localized);
 
     let function_name = std::mem::replace(&mut inv.function.sig.ident, syn::parse_quote! { inner });
+    let function_generics = &inv.function.sig.generics;
     let function_visibility = &inv.function.vis;
     let function = &inv.function;
     Ok(quote::quote! {
         #[allow(clippy::str_to_string)]
-        #function_visibility fn #function_name() -> ::poise::Command<
+        #function_visibility fn #function_name #function_generics() -> ::poise::Command<
             <#ctx_type_with_static as poise::_GetGenerics>::U,
             <#ctx_type_with_static as poise::_GetGenerics>::E,
         > {


### PR DESCRIPTION
This pull request implements generic functions to be used with the` #[poise::command]` procedural macro that is used in the current branch.

