### PR TITLE
Port poise to use serenity data generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,8 +1326,7 @@ dependencies = [
 [[package]]
 name = "serenity"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385647faa24a889929028973650a4f158fb1b4272b2fcf94feb9fcc3c009e813"
+source = "git+https://github.com/gnomeddev/serenity?branch=typemap-be-gone#994ca84dde9df2148b3fa01ca8a731ead58d0bab"
 dependencies = [
  "arrayvec",
  "async-trait",
@@ -1336,6 +1335,7 @@ dependencies = [
  "bytes",
  "chrono",
  "dashmap",
+ "derivative",
  "flate2",
  "futures",
  "fxhash",
@@ -1350,7 +1350,6 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
- "typemap_rev",
  "typesize",
  "url",
 ]
@@ -1717,12 +1716,6 @@ checksum = "b6d3364c5e96cb2ad1603037ab253ddd34d7fb72a58bdddf4b7350760fc69a46"
 dependencies = [
  "rustc-hash",
 ]
-
-[[package]]
-name = "typemap_rev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ parking_lot = "0.12.1"
 [dependencies.serenity]
 default-features = false
 features = ["builder", "client", "gateway", "model", "utils", "collector", "framework"]
-version = "0.12.0"
+git = "https://github.com/gnomeddev/serenity"
+branch = "typemap-be-gone"
 
 [dev-dependencies]
 # For the examples

--- a/examples/advanced_cooldowns/main.rs
+++ b/examples/advanced_cooldowns/main.rs
@@ -41,14 +41,15 @@ async fn main() {
         .setup(|ctx, _ready, framework| {
             Box::pin(async move {
                 poise::builtins::register_globally(ctx, &framework.options().commands).await?;
-                Ok(Data {})
+                Ok(())
             })
         })
         .build();
 
-    let client = serenity::Client::builder(token, serenity::GatewayIntents::non_privileged())
-        .framework(framework)
-        .await;
+    let client =
+        serenity::Client::builder(token, serenity::GatewayIntents::non_privileged(), Data {})
+            .framework(framework)
+            .await;
 
     client.unwrap().start().await.unwrap();
 }

--- a/examples/basic_structure/main.rs
+++ b/examples/basic_structure/main.rs
@@ -81,7 +81,7 @@ async fn main() {
         // Enforce command checks even for owners (enforced by default)
         // Set to true to bypass checks, which is useful for testing
         skip_checks_for_owners: false,
-        event_handler: |_ctx, event, _framework, _data| {
+        event_handler: |_ctx, event, _framework| {
             Box::pin(async move {
                 println!(
                     "Got an event in event handler: {:?}",
@@ -93,14 +93,16 @@ async fn main() {
         ..Default::default()
     };
 
+    let data = Data {
+        votes: Mutex::new(HashMap::new()),
+    };
+
     let framework = poise::Framework::builder()
         .setup(move |ctx, _ready, framework| {
             Box::pin(async move {
                 println!("Logged in as {}", _ready.user.name);
                 poise::builtins::register_globally(ctx, &framework.options().commands).await?;
-                Ok(Data {
-                    votes: Mutex::new(HashMap::new()),
-                })
+                Ok(())
             })
         })
         .options(options)
@@ -111,7 +113,7 @@ async fn main() {
     let intents =
         serenity::GatewayIntents::non_privileged() | serenity::GatewayIntents::MESSAGE_CONTENT;
 
-    let client = serenity::ClientBuilder::new(token, intents)
+    let client = serenity::ClientBuilder::new(token, intents, data)
         .framework(framework)
         .await;
 

--- a/examples/feature_showcase/main.rs
+++ b/examples/feature_showcase/main.rs
@@ -94,7 +94,7 @@ async fn main() {
         .setup(move |ctx, _ready, framework| {
             Box::pin(async move {
                 poise::builtins::register_globally(ctx, &framework.options().commands).await?;
-                Ok(Data {})
+                Ok(())
             })
         })
         .build();
@@ -103,7 +103,7 @@ async fn main() {
     let intents =
         serenity::GatewayIntents::non_privileged() | serenity::GatewayIntents::MESSAGE_CONTENT;
 
-    let client = serenity::ClientBuilder::new(token, intents)
+    let client = serenity::ClientBuilder::new(token, intents, Data {})
         .framework(framework)
         .await;
 

--- a/examples/feature_showcase/modal.rs
+++ b/examples/feature_showcase/modal.rs
@@ -43,7 +43,8 @@ pub async fn component_modal(ctx: crate::Context<'_>) -> Result<(), Error> {
         .await
     {
         let data =
-            poise::execute_modal_on_component_interaction::<MyModal>(ctx, mci, None, None).await?;
+            poise::execute_modal_on_component_interaction::<MyModal, _>(ctx, mci, None, None)
+                .await?;
         println!("Got data: {:?}", data);
     }
     Ok(())

--- a/examples/fluent_localization/main.rs
+++ b/examples/fluent_localization/main.rs
@@ -72,10 +72,9 @@ async fn main() {
             commands,
             ..Default::default()
         })
-        .setup(move |_, _, _| Box::pin(async move { Ok(Data { translations }) }))
         .build();
 
-    let client = serenity::ClientBuilder::new(token, intents)
+    let client = serenity::ClientBuilder::new(token, intents, Data { translations })
         .framework(framework)
         .await;
 

--- a/examples/generic_commands/main.rs
+++ b/examples/generic_commands/main.rs
@@ -4,7 +4,7 @@
 //! The original use case for this feature was to have the same command in two different bots
 
 #[poise::command(slash_command)]
-pub async fn example<U: Sync, E>(ctx: poise::Context<'_, U, E>) -> Result<(), E> {
+pub async fn example<U: Sync + Send, E>(ctx: poise::Context<'_, U, E>) -> Result<(), E> {
     ctx.say(format!(
         "My user data type is {} and the error type is {}",
         std::any::type_name::<U>(),

--- a/examples/help_generation/main.rs
+++ b/examples/help_generation/main.rs
@@ -345,12 +345,12 @@ async fn main() {
         .setup(|ctx, _ready, framework| {
             Box::pin(async move {
                 poise::builtins::register_globally(ctx, &framework.options().commands).await?;
-                Ok(Data {})
+                Ok(())
             })
         })
         .build();
 
-    let client = serenity::ClientBuilder::new(token, intents)
+    let client = serenity::ClientBuilder::new(token, intents, Data {})
         .framework(framework)
         .await;
 

--- a/examples/invocation_data/main.rs
+++ b/examples/invocation_data/main.rs
@@ -121,7 +121,7 @@ async fn main() {
         })
         .build();
 
-    let client = serenity::ClientBuilder::new(token, intents)
+    let client = serenity::ClientBuilder::new(token, intents, ())
         .framework(framework)
         .await;
 

--- a/examples/manual_dispatch/main.rs
+++ b/examples/manual_dispatch/main.rs
@@ -6,6 +6,7 @@
 
 use poise::serenity_prelude as serenity;
 
+type Data = ();
 type Error = serenity::Error;
 
 #[poise::command(prefix_command)]
@@ -19,14 +20,13 @@ struct Handler {
     shard_manager: std::sync::Mutex<Option<std::sync::Arc<serenity::ShardManager>>>,
 }
 #[serenity::async_trait]
-impl serenity::EventHandler for Handler {
-    async fn message(&self, ctx: serenity::Context, new_message: serenity::Message) {
+impl serenity::EventHandler<Data> for Handler {
+    async fn message(&self, ctx: serenity::Context<Data>, new_message: serenity::Message) {
         // FrameworkContext contains all data that poise::Framework usually manages
         let shard_manager = (*self.shard_manager.lock().unwrap()).clone().unwrap();
         let framework_data = poise::FrameworkContext {
             bot_id: serenity::UserId::new(846453852164587620),
             options: &self.options,
-            user_data: &(),
             shard_manager: &shard_manager,
         };
 
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Error> {
     poise::set_qualified_names(&mut handler.options.commands); // some setup
 
     let handler = std::sync::Arc::new(handler);
-    let mut client = serenity::Client::builder(token, intents)
+    let mut client = serenity::Client::builder(token, intents, ())
         .event_handler_arc(handler.clone())
         .await?;
 

--- a/examples/quickstart/main.rs
+++ b/examples/quickstart/main.rs
@@ -29,12 +29,12 @@ async fn main() {
         .setup(|ctx, _ready, framework| {
             Box::pin(async move {
                 poise::builtins::register_globally(ctx, &framework.options().commands).await?;
-                Ok(Data {})
+                Ok(())
             })
         })
         .build();
 
-    let client = serenity::ClientBuilder::new(token, intents)
+    let client = serenity::ClientBuilder::new(token, intents, Data {})
         .framework(framework)
         .await;
     client.unwrap().start().await.unwrap();

--- a/src/builtins/help.rs
+++ b/src/builtins/help.rs
@@ -85,7 +85,9 @@ impl TwoColumnList {
 }
 
 /// Get the prefix from options
-async fn get_prefix_from_options<U, E>(ctx: crate::Context<'_, U, E>) -> Option<String> {
+async fn get_prefix_from_options<U: Send + Sync + 'static, E>(
+    ctx: crate::Context<'_, U, E>,
+) -> Option<String> {
     let options = &ctx.framework().options().prefix_options;
     match &options.prefix {
         Some(fixed_prefix) => Some(fixed_prefix.clone()),
@@ -102,7 +104,9 @@ async fn get_prefix_from_options<U, E>(ctx: crate::Context<'_, U, E>) -> Option<
 }
 
 /// Format context menu command name
-fn format_context_menu_name<U, E>(command: &crate::Command<U, E>) -> Option<String> {
+fn format_context_menu_name<U: Send + Sync + 'static, E>(
+    command: &crate::Command<U, E>,
+) -> Option<String> {
     let kind = match command.context_menu_action {
         Some(crate::ContextMenuCommandAction::User(_)) => "user",
         Some(crate::ContextMenuCommandAction::Message(_)) => "message",
@@ -120,7 +124,7 @@ fn format_context_menu_name<U, E>(command: &crate::Command<U, E>) -> Option<Stri
 }
 
 /// Code for printing help of a specific command (e.g. `~help my_command`)
-async fn help_single_command<U, E>(
+async fn help_single_command<U: Send + Sync + 'static, E>(
     ctx: crate::Context<'_, U, E>,
     command_name: &str,
     config: HelpConfiguration<'_>,
@@ -234,7 +238,7 @@ async fn help_single_command<U, E>(
 }
 
 /// Recursively formats all subcommands
-fn preformat_subcommands<U, E>(
+fn preformat_subcommands<U: Send + Sync + 'static, E>(
     commands: &mut TwoColumnList,
     command: &crate::Command<U, E>,
     prefix: &str,
@@ -259,7 +263,7 @@ fn preformat_subcommands<U, E>(
 }
 
 /// Preformat lines (except for padding,) like `("  /ping", "Emits a ping message")`
-fn preformat_command<U, E>(
+fn preformat_command<U: Send + Sync + 'static, E>(
     commands: &mut TwoColumnList,
     config: &HelpConfiguration<'_>,
     command: &crate::Command<U, E>,
@@ -289,7 +293,7 @@ fn preformat_command<U, E>(
 /// Create help text for `help_all_commands`
 ///
 /// This is a separate function so we can have tests for it
-async fn generate_all_commands<U, E>(
+async fn generate_all_commands<U: Send + Sync + 'static, E>(
     ctx: crate::Context<'_, U, E>,
     config: &HelpConfiguration<'_>,
 ) -> Result<String, serenity::Error> {
@@ -348,7 +352,7 @@ async fn generate_all_commands<U, E>(
 }
 
 /// Code for printing an overview of all commands (e.g. `~help`)
-async fn help_all_commands<U, E>(
+async fn help_all_commands<U: Send + Sync + 'static, E>(
     ctx: crate::Context<'_, U, E>,
     config: HelpConfiguration<'_>,
 ) -> Result<(), serenity::Error> {
@@ -414,7 +418,7 @@ async fn help_all_commands<U, E>(
 /// Type ?help command for more info on a command.
 /// You can edit your message to the bot and the bot will edit its response.
 /// ```
-pub async fn help<U, E>(
+pub async fn help<U: Send + Sync + 'static, E>(
     ctx: crate::Context<'_, U, E>,
     command: Option<&str>,
     config: HelpConfiguration<'_>,

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -32,7 +32,7 @@ use crate::{serenity_prelude as serenity, CreateReply};
 /// }
 /// # };
 /// ```
-pub async fn on_error<U, E: std::fmt::Display + std::fmt::Debug>(
+pub async fn on_error<U: Send + Sync + 'static, E: std::fmt::Display + std::fmt::Debug>(
     error: crate::FrameworkError<'_, U, E>,
 ) -> Result<(), serenity::Error> {
     match error {
@@ -199,7 +199,7 @@ pub async fn on_error<U, E: std::fmt::Display + std::fmt::Debug>(
 ///
 /// See `examples/feature_showcase` for an example
 #[allow(clippy::unused_async)] // Required for the return type
-pub async fn autocomplete_command<'a, U, E>(
+pub async fn autocomplete_command<'a, U: Send + Sync + 'static, E>(
     ctx: crate::Context<'a, U, E>,
     partial: &'a str,
 ) -> impl Iterator<Item = String> + 'a {
@@ -224,7 +224,9 @@ pub async fn autocomplete_command<'a, U, E>(
 /// > - **A public server** (7123 members)
 /// > - [3 private servers with 456 members total]
 #[cfg(feature = "cache")]
-pub async fn servers<U, E>(ctx: crate::Context<'_, U, E>) -> Result<(), serenity::Error> {
+pub async fn servers<U: Send + Sync + 'static, E>(
+    ctx: crate::Context<'_, U, E>,
+) -> Result<(), serenity::Error> {
     use std::fmt::Write as _;
 
     let show_private_guilds = ctx.framework().options().owners.contains(&ctx.author().id);

--- a/src/builtins/paginate.rs
+++ b/src/builtins/paginate.rs
@@ -32,7 +32,7 @@ use crate::serenity_prelude as serenity;
 /// ```
 ///
 /// ![Screenshot of output](https://i.imgur.com/JGFDveA.png)
-pub async fn paginate<U, E>(
+pub async fn paginate<U: Send + Sync + 'static, E>(
     ctx: crate::Context<'_, U, E>,
     pages: &[&str],
 ) -> Result<(), serenity::Error> {

--- a/src/builtins/register.rs
+++ b/src/builtins/register.rs
@@ -16,14 +16,14 @@ use crate::serenity_prelude as serenity;
 /// serenity::Command::set_global_commands(ctx, create_commands).await?;
 /// # Ok(()) }
 /// ```
-pub fn create_application_commands<U, E>(
+pub fn create_application_commands<U: Send + Sync + 'static, E>(
     commands: &[crate::Command<U, E>],
 ) -> Vec<serenity::CreateCommand> {
     /// We decided to extract context menu commands recursively, despite the subcommand hierarchy
     /// not being preserved. Because it's more confusing to just silently discard context menu
     /// commands if they're not top-level commands.
     /// https://discord.com/channels/381880193251409931/919310428344029265/947970605985189989
-    fn recursively_add_context_menu_commands<U, E>(
+    fn recursively_add_context_menu_commands<U: Send + Sync + 'static, E>(
         builder: &mut Vec<serenity::CreateCommand>,
         command: &crate::Command<U, E>,
     ) {
@@ -49,7 +49,7 @@ pub fn create_application_commands<U, E>(
 ///
 /// Thin wrapper around [`create_application_commands`] that funnels the returned builder into
 /// [`serenity::Command::set_global_commands`].
-pub async fn register_globally<U, E>(
+pub async fn register_globally<U: Send + Sync + 'static, E>(
     http: impl AsRef<serenity::Http>,
     commands: &[crate::Command<U, E>],
 ) -> Result<(), serenity::Error> {
@@ -62,7 +62,7 @@ pub async fn register_globally<U, E>(
 ///
 /// Thin wrapper around [`create_application_commands`] that funnels the returned builder into
 /// [`serenity::GuildId::set_commands`].
-pub async fn register_in_guild<U, E>(
+pub async fn register_in_guild<U: Send + Sync + 'static, E>(
     http: impl AsRef<serenity::Http>,
     commands: &[crate::Command<U, E>],
     guild_id: serenity::GuildId,
@@ -85,7 +85,7 @@ pub async fn register_in_guild<U, E>(
 ///
 /// Run with no arguments to register in guild, run with argument "global" to register globally.
 /// ```
-pub async fn register_application_commands<U, E>(
+pub async fn register_application_commands<U: Send + Sync + 'static, E>(
     ctx: crate::Context<'_, U, E>,
     global: bool,
 ) -> Result<(), serenity::Error> {
@@ -148,7 +148,7 @@ pub async fn register_application_commands<U, E>(
 /// ```
 ///
 /// Which you can call like any prefix command, for example `@your_bot register`.
-pub async fn register_application_commands_buttons<U, E>(
+pub async fn register_application_commands_buttons<U: Send + Sync + 'static, E>(
     ctx: crate::Context<'_, U, E>,
 ) -> Result<(), serenity::Error> {
     let create_commands = create_application_commands(&ctx.framework().options().commands);

--- a/src/choice_parameter.rs
+++ b/src/choice_parameter.rs
@@ -24,8 +24,8 @@ pub trait ChoiceParameter: Sized {
 
 #[async_trait::async_trait]
 impl<T: ChoiceParameter> crate::SlashArgument for T {
-    async fn extract(
-        _: &serenity::Context,
+    async fn extract<U: Send + Sync + 'static>(
+        _: &serenity::Context<U>,
         _: &serenity::CommandInteraction,
         value: &serenity::ResolvedValue<'_>,
     ) -> ::std::result::Result<Self, crate::SlashArgError> {
@@ -57,10 +57,10 @@ impl<T: ChoiceParameter> crate::SlashArgument for T {
 
 #[async_trait::async_trait]
 impl<'a, T: ChoiceParameter> crate::PopArgument<'a> for T {
-    async fn pop_from(
+    async fn pop_from<U: Send + Sync + 'static>(
         args: &'a str,
         attachment_index: usize,
-        ctx: &serenity::Context,
+        ctx: &serenity::Context<U>,
         msg: &serenity::Message,
     ) -> Result<(&'a str, usize, Self), (Box<dyn std::error::Error + Send + Sync>, Option<String>)>
     {

--- a/src/dispatch/common.rs
+++ b/src/dispatch/common.rs
@@ -4,8 +4,8 @@ use crate::serenity_prelude as serenity;
 
 /// Retrieves user permissions in the given channel. If unknown, returns None. If in DMs, returns
 /// `Permissions::all()`.
-async fn user_permissions(
-    ctx: &serenity::Context,
+async fn user_permissions<U: Send + Sync>(
+    ctx: &serenity::Context<U>,
     guild_id: Option<serenity::GuildId>,
     channel_id: serenity::ChannelId,
     user_id: serenity::UserId,
@@ -37,7 +37,7 @@ async fn user_permissions(
 /// Retrieves the set of permissions that are lacking, relative to the given required permission set
 ///
 /// Returns None if permissions couldn't be retrieved
-async fn missing_permissions<U, E>(
+async fn missing_permissions<U: Send + Sync + 'static, E>(
     ctx: crate::Context<'_, U, E>,
     user: serenity::UserId,
     required_permissions: serenity::Permissions,
@@ -61,7 +61,10 @@ async fn missing_permissions<U, E>(
 async fn check_permissions_and_cooldown_single<'a, U, E>(
     ctx: crate::Context<'a, U, E>,
     cmd: &'a crate::Command<U, E>,
-) -> Result<(), crate::FrameworkError<'a, U, E>> {
+) -> Result<(), crate::FrameworkError<'a, U, E>>
+where
+    U: Send + Sync + 'static,
+{
     // Skip command checks if `FrameworkOptions::skip_checks_for_owners` is set to true
     if ctx.framework().options.skip_checks_for_owners
         && ctx.framework().options().owners.contains(&ctx.author().id)
@@ -180,7 +183,10 @@ async fn check_permissions_and_cooldown_single<'a, U, E>(
 #[allow(clippy::needless_lifetimes)] // false positive (clippy issue 7271)
 pub async fn check_permissions_and_cooldown<'a, U, E>(
     ctx: crate::Context<'a, U, E>,
-) -> Result<(), crate::FrameworkError<'a, U, E>> {
+) -> Result<(), crate::FrameworkError<'a, U, E>>
+where
+    U: Send + Sync + 'static,
+{
     for parent_command in ctx.parent_commands() {
         check_permissions_and_cooldown_single(ctx, parent_command).await?;
     }

--- a/src/dispatch/slash.rs
+++ b/src/dispatch/slash.rs
@@ -3,7 +3,7 @@
 use crate::serenity_prelude as serenity;
 
 /// Check if the interaction with the given name and arguments matches any framework command
-fn find_matching_command<'a, 'b, U, E>(
+fn find_matching_command<'a, 'b, U: Send + Sync + 'static, E>(
     interaction_name: &str,
     interaction_options: &'b [serenity::ResolvedOption<'b>],
     commands: &'a [crate::Command<U, E>],
@@ -38,9 +38,9 @@ fn find_matching_command<'a, 'b, U, E>(
 /// After this, the [`crate::ApplicationContext`] should be passed into [`run_command`] or
 /// [`run_autocomplete`].
 #[allow(clippy::too_many_arguments)] // We need to pass them all in to create Context.
-fn extract_command<'a, U, E>(
+fn extract_command<'a, U: Send + Sync + 'static, E>(
     framework: crate::FrameworkContext<'a, U, E>,
-    ctx: &'a serenity::Context,
+    ctx: &'a serenity::Context<U>,
     interaction: &'a serenity::CommandInteraction,
     interaction_type: crate::CommandInteractionType,
     has_sent_initial_response: &'a std::sync::atomic::AtomicBool,
@@ -62,7 +62,6 @@ fn extract_command<'a, U, E>(
         })?;
 
     Ok(crate::ApplicationContext {
-        data: framework.user_data,
         serenity_context: ctx,
         framework,
         interaction,
@@ -78,9 +77,9 @@ fn extract_command<'a, U, E>(
 
 /// Given an interaction, finds the matching framework command and checks if the user is allowed access
 #[allow(clippy::too_many_arguments)] // We need to pass them all in to create Context.
-pub async fn extract_command_and_run_checks<'a, U, E>(
+pub async fn extract_command_and_run_checks<'a, U: Send + Sync + 'static, E>(
     framework: crate::FrameworkContext<'a, U, E>,
-    ctx: &'a serenity::Context,
+    ctx: &'a serenity::Context<U>,
     interaction: &'a serenity::CommandInteraction,
     interaction_type: crate::CommandInteractionType,
     has_sent_initial_response: &'a std::sync::atomic::AtomicBool,
@@ -104,7 +103,7 @@ pub async fn extract_command_and_run_checks<'a, U, E>(
 
 /// Given the extracted application command data from [`extract_command`], runs the command,
 /// including all the before and after code like checks.
-async fn run_command<U, E>(
+async fn run_command<U: Send + Sync + 'static, E>(
     ctx: crate::ApplicationContext<'_, U, E>,
 ) -> Result<(), crate::FrameworkError<'_, U, E>> {
     super::common::check_permissions_and_cooldown(ctx.into()).await?;
@@ -163,9 +162,9 @@ async fn run_command<U, E>(
 }
 
 /// Dispatches this interaction onto framework commands, i.e. runs the associated command
-pub async fn dispatch_interaction<'a, U, E>(
+pub async fn dispatch_interaction<'a, U: Send + Sync + 'static, E>(
     framework: crate::FrameworkContext<'a, U, E>,
-    ctx: &'a serenity::Context,
+    ctx: &'a serenity::Context<U>,
     interaction: &'a serenity::CommandInteraction,
     // Need to pass this in from outside because of lifetime issues
     has_sent_initial_response: &'a std::sync::atomic::AtomicBool,
@@ -198,7 +197,7 @@ pub async fn dispatch_interaction<'a, U, E>(
 
 /// Given the extracted application command data from [`extract_command`], runs the autocomplete
 /// callbacks, including all the before and after code like checks.
-async fn run_autocomplete<U, E>(
+async fn run_autocomplete<U: Send + Sync + 'static, E>(
     ctx: crate::ApplicationContext<'_, U, E>,
 ) -> Result<(), crate::FrameworkError<'_, U, E>> {
     super::common::check_permissions_and_cooldown(ctx.into()).await?;
@@ -260,9 +259,9 @@ async fn run_autocomplete<U, E>(
 
 /// Dispatches this interaction onto framework commands, i.e. runs the associated autocomplete
 /// callback
-pub async fn dispatch_autocomplete<'a, U, E>(
+pub async fn dispatch_autocomplete<'a, U: Send + Sync + 'static, E>(
     framework: crate::FrameworkContext<'a, U, E>,
-    ctx: &'a serenity::Context,
+    ctx: &'a serenity::Context<U>,
     interaction: &'a serenity::CommandInteraction,
     // Need to pass the following in from outside because of lifetime issues
     has_sent_initial_response: &'a std::sync::atomic::AtomicBool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,11 +233,6 @@ use poise::serenity_prelude as serenity;
 // Use `Framework::builder()` to create a framework builder and supply basic data to the framework:
 
 let framework = poise::Framework::builder()
-    .setup(|_, _, _| Box::pin(async move {
-        // construct user data here (invoked when bot connects to Discord)
-        Ok(())
-    }))
-
     // Most configuration is done via the `FrameworkOptions` struct, which you can define with
     // a struct literal (hint: use `..Default::default()` to fill uninitialized
     // settings with their default value):
@@ -262,7 +257,7 @@ let framework = poise::Framework::builder()
         ..Default::default()
     }).build();
 
-let client = serenity::ClientBuilder::new("...", serenity::GatewayIntents::non_privileged())
+let client = serenity::ClientBuilder::new("...", serenity::GatewayIntents::non_privileged(), ())
     .framework(framework).await;
 
 client.unwrap().start().await.unwrap();

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -42,9 +42,10 @@ pub fn find_modal_text(
 /// interaction
 async fn execute_modal_generic<
     M: Modal,
+    U: Send + Sync,
     F: std::future::Future<Output = Result<(), serenity::Error>>,
 >(
-    ctx: &serenity::Context,
+    ctx: &serenity::Context<U>,
     create_interaction_response: impl FnOnce(serenity::CreateInteractionResponse) -> F,
     modal_custom_id: String,
     defaults: Option<M>,
@@ -119,8 +120,8 @@ pub async fn execute_modal<U: Send + Sync, E, M: Modal>(
 ///
 /// If you need more specialized behavior, you can copy paste the implementation of this function
 /// and adjust to your needs. The code of this function is just a starting point.
-pub async fn execute_modal_on_component_interaction<M: Modal>(
-    ctx: impl AsRef<serenity::Context>,
+pub async fn execute_modal_on_component_interaction<M: Modal, U: Send + Sync + 'static>(
+    ctx: impl AsRef<serenity::Context<U>>,
     interaction: serenity::ModalInteraction,
     defaults: Option<M>,
     timeout: Option<std::time::Duration>,

--- a/src/prefix_argument/argument_trait.rs
+++ b/src/prefix_argument/argument_trait.rs
@@ -34,10 +34,10 @@ pub trait PopArgument<'a>: Sized {
     /// If parsing fails because the string is empty, use the `TooFewArguments` type as the error.
     ///
     /// Don't call this method directly! Use [`crate::pop_prefix_argument!`]
-    async fn pop_from(
+    async fn pop_from<U: Send + Sync + 'static>(
         args: &'a str,
         attachment_index: usize,
-        ctx: &serenity::Context,
+        ctx: &serenity::Context<U>,
         msg: &serenity::Message,
     ) -> Result<(&'a str, usize, Self), (Box<dyn std::error::Error + Send + Sync>, Option<String>)>;
 }
@@ -45,11 +45,11 @@ pub trait PopArgument<'a>: Sized {
 #[doc(hidden)]
 #[async_trait::async_trait]
 pub trait PopArgumentHack<'a, T>: Sized {
-    async fn pop_from(
+    async fn pop_from<U: Send + Sync>(
         self,
         args: &'a str,
         attachment_index: usize,
-        ctx: &serenity::Context,
+        ctx: &serenity::Context<U>,
         msg: &serenity::Message,
     ) -> Result<(&'a str, usize, T), (Box<dyn std::error::Error + Send + Sync>, Option<String>)>;
 }
@@ -59,11 +59,11 @@ impl<'a, T: serenity::ArgumentConvert + Send> PopArgumentHack<'a, T> for Phantom
 where
     T::Err: std::error::Error + Send + Sync + 'static,
 {
-    async fn pop_from(
+    async fn pop_from<U: Send + Sync>(
         self,
         args: &'a str,
         attachment_index: usize,
-        ctx: &serenity::Context,
+        ctx: &serenity::Context<U>,
         msg: &serenity::Message,
     ) -> Result<(&'a str, usize, T), (Box<dyn std::error::Error + Send + Sync>, Option<String>)>
     {
@@ -79,11 +79,11 @@ where
 
 #[async_trait::async_trait]
 impl<'a, T: PopArgument<'a> + Send + Sync> PopArgumentHack<'a, T> for &PhantomData<T> {
-    async fn pop_from(
+    async fn pop_from<U: Send + Sync + 'static>(
         self,
         args: &'a str,
         attachment_index: usize,
-        ctx: &serenity::Context,
+        ctx: &serenity::Context<U>,
         msg: &serenity::Message,
     ) -> Result<(&'a str, usize, T), (Box<dyn std::error::Error + Send + Sync>, Option<String>)>
     {
@@ -93,11 +93,11 @@ impl<'a, T: PopArgument<'a> + Send + Sync> PopArgumentHack<'a, T> for &PhantomDa
 
 #[async_trait::async_trait]
 impl<'a> PopArgumentHack<'a, bool> for &PhantomData<bool> {
-    async fn pop_from(
+    async fn pop_from<U: Send + Sync + 'static>(
         self,
         args: &'a str,
         attachment_index: usize,
-        ctx: &serenity::Context,
+        ctx: &serenity::Context<U>,
         msg: &serenity::Message,
     ) -> Result<(&'a str, usize, bool), (Box<dyn std::error::Error + Send + Sync>, Option<String>)>
     {
@@ -116,11 +116,11 @@ impl<'a> PopArgumentHack<'a, bool> for &PhantomData<bool> {
 
 #[async_trait::async_trait]
 impl<'a> PopArgumentHack<'a, serenity::Attachment> for &PhantomData<serenity::Attachment> {
-    async fn pop_from(
+    async fn pop_from<U: Send + Sync + 'static>(
         self,
         args: &'a str,
         attachment_index: usize,
-        ctx: &serenity::Context,
+        ctx: &serenity::Context<U>,
         msg: &serenity::Message,
     ) -> Result<
         (&'a str, usize, serenity::Attachment),

--- a/src/prefix_argument/code_block.rs
+++ b/src/prefix_argument/code_block.rs
@@ -114,10 +114,10 @@ impl<'a> PopArgument<'a> for CodeBlock {
     /// Parse a single-line or multi-line code block. The output of `Self::code` should mirror what
     /// the official Discord client renders, and the output of `Self::language` should mirror the
     /// official Discord client's syntax highlighting, if existent.
-    async fn pop_from(
+    async fn pop_from<U: Send + Sync + 'static>(
         args: &'a str,
         attachment_index: usize,
-        _: &serenity::Context,
+        _: &serenity::Context<U>,
         _: &serenity::Message,
     ) -> Result<(&'a str, usize, Self), (Box<dyn std::error::Error + Send + Sync>, Option<String>)>
     {

--- a/src/prefix_argument/key_value_args.rs
+++ b/src/prefix_argument/key_value_args.rs
@@ -73,10 +73,10 @@ impl KeyValueArgs {
 
 #[async_trait::async_trait]
 impl<'a> PopArgument<'a> for KeyValueArgs {
-    async fn pop_from(
+    async fn pop_from<U: Send + Sync + 'static>(
         args: &'a str,
         attachment_index: usize,
-        _: &serenity::Context,
+        _: &serenity::Context<U>,
         _: &serenity::Message,
     ) -> Result<(&'a str, usize, Self), (Box<dyn std::error::Error + Send + Sync>, Option<String>)>
     {

--- a/src/prefix_argument/macros.rs
+++ b/src/prefix_argument/macros.rs
@@ -179,9 +179,9 @@ to use this macro directly.
 # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 # use poise::serenity_prelude as serenity;
 # let ctx = serenity::Context {
-#     data: Default::default(),
 #     shard: todo!(),
 #     shard_id: todo!(),
+#     data: std::sync::Arc::new(()),
 #     http: std::sync::Arc::new(::serenity::http::Http::new("example")),
 #     #[cfg(feature = "cache")]
 #     cache: Default::default(),

--- a/src/reply/mod.rs
+++ b/src/reply/mod.rs
@@ -93,7 +93,7 @@ impl ReplyHandle<'_> {
     // TODO: return the edited Message object?
     // TODO: should I eliminate the ctx parameter by storing it in self instead? Would infect
     //  ReplyHandle with <U, E> type parameters
-    pub async fn edit<'att, U, E>(
+    pub async fn edit<'att, U: Send + Sync + 'static, E>(
         &self,
         ctx: crate::Context<'_, U, E>,
         builder: CreateReply,
@@ -139,7 +139,10 @@ impl ReplyHandle<'_> {
     }
 
     /// Deletes this message
-    pub async fn delete<U, E>(&self, ctx: crate::Context<'_, U, E>) -> Result<(), serenity::Error> {
+    pub async fn delete<U: Send + Sync + 'static, E>(
+        &self,
+        ctx: crate::Context<'_, U, E>,
+    ) -> Result<(), serenity::Error> {
         match &self.0 {
             ReplyHandleInner::Prefix(msg) => msg.delete(ctx.serenity_context()).await?,
             ReplyHandleInner::Application {

--- a/src/reply/send_reply.rs
+++ b/src/reply/send_reply.rs
@@ -23,7 +23,7 @@ use crate::serenity_prelude as serenity;
 /// ).await?;
 /// # Ok(()) }
 /// ```
-pub async fn send_reply<U, E>(
+pub async fn send_reply<U: Send + Sync + 'static, E>(
     ctx: crate::Context<'_, U, E>,
     builder: crate::CreateReply,
 ) -> Result<crate::ReplyHandle<'_>, serenity::Error> {
@@ -38,7 +38,7 @@ pub async fn send_reply<U, E>(
 /// Shorthand of [`send_reply`] for text-only messages
 ///
 /// Note: panics when called in an autocomplete context!
-pub async fn say_reply<U, E>(
+pub async fn say_reply<U: Send + Sync + 'static, E>(
     ctx: crate::Context<'_, U, E>,
     text: impl Into<String>,
 ) -> Result<crate::ReplyHandle<'_>, serenity::Error> {
@@ -51,7 +51,7 @@ pub async fn say_reply<U, E>(
 /// [followup](serenity::CommandInteraction::create_followup) is sent.
 ///
 /// No-op if autocomplete context
-pub async fn send_application_reply<U, E>(
+pub async fn send_application_reply<U: Send + Sync + 'static, E>(
     ctx: crate::ApplicationContext<'_, U, E>,
     builder: crate::CreateReply,
 ) -> Result<crate::ReplyHandle<'_>, serenity::Error> {
@@ -98,7 +98,7 @@ pub async fn send_application_reply<U, E>(
 }
 
 /// Prefix-specific reply function. For more details, see [`crate::send_reply`].
-pub async fn send_prefix_reply<U, E>(
+pub async fn send_prefix_reply<U: Send + Sync + 'static, E>(
     ctx: crate::PrefixContext<'_, U, E>,
     builder: crate::CreateReply,
 ) -> Result<Box<serenity::Message>, serenity::Error> {

--- a/src/slash_argument/context_menu.rs
+++ b/src/slash_argument/context_menu.rs
@@ -3,7 +3,7 @@ use crate::serenity_prelude as serenity;
 use crate::BoxFuture;
 
 /// Implemented for all types that can be used in a context menu command
-pub trait ContextMenuParameter<U, E> {
+pub trait ContextMenuParameter<U: Send + Sync + 'static, E> {
     /// Convert an action function pointer that takes Self as an argument into the appropriate
     /// [`crate::ContextMenuCommandAction`] variant.
     fn to_action(
@@ -14,7 +14,7 @@ pub trait ContextMenuParameter<U, E> {
     ) -> crate::ContextMenuCommandAction<U, E>;
 }
 
-impl<U, E> ContextMenuParameter<U, E> for serenity::User {
+impl<U: Send + Sync + 'static, E> ContextMenuParameter<U, E> for serenity::User {
     fn to_action(
         action: fn(
             crate::ApplicationContext<'_, U, E>,
@@ -25,7 +25,7 @@ impl<U, E> ContextMenuParameter<U, E> for serenity::User {
     }
 }
 
-impl<U, E> ContextMenuParameter<U, E> for serenity::Message {
+impl<U: Send + Sync + 'static, E> ContextMenuParameter<U, E> for serenity::Message {
     fn to_action(
         action: fn(
             crate::ApplicationContext<'_, U, E>,

--- a/src/slash_argument/slash_macro.rs
+++ b/src/slash_argument/slash_macro.rs
@@ -108,7 +108,7 @@ directly.
 ```rust,no_run
 # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 # use poise::serenity_prelude as serenity;
-let ctx: serenity::Context = todo!();
+let ctx: serenity::Context<()> = todo!();
 let interaction: serenity::CommandInteraction = todo!();
 let args: &[serenity::ResolvedOption] = todo!();
 

--- a/src/slash_argument/slash_trait.rs
+++ b/src/slash_argument/slash_trait.rs
@@ -15,8 +15,8 @@ pub trait SlashArgument: Sized {
     /// [`serenity::json::Value`].
     ///
     /// Don't call this method directly! Use [`crate::extract_slash_argument!`]
-    async fn extract(
-        ctx: &serenity::Context,
+    async fn extract<U: Send + Sync + 'static>(
+        ctx: &serenity::Context<U>,
         interaction: &serenity::CommandInteraction,
         value: &serenity::ResolvedValue<'_>,
     ) -> Result<Self, SlashArgError>;
@@ -44,9 +44,9 @@ pub trait SlashArgument: Sized {
 #[doc(hidden)]
 #[async_trait::async_trait]
 pub trait SlashArgumentHack<T>: Sized {
-    async fn extract(
+    async fn extract<U: Send + Sync + 'static>(
         self,
-        ctx: &serenity::Context,
+        ctx: &serenity::Context<U>,
         interaction: &serenity::CommandInteraction,
         value: &serenity::ResolvedValue<'_>,
     ) -> Result<T, SlashArgError>;
@@ -96,9 +96,9 @@ where
     T: serenity::ArgumentConvert + Send + Sync,
     T::Err: std::error::Error + Send + Sync + 'static,
 {
-    async fn extract(
+    async fn extract<U: Send + Sync + 'static>(
         self,
-        ctx: &serenity::Context,
+        ctx: &serenity::Context<U>,
         interaction: &serenity::CommandInteraction,
         value: &serenity::ResolvedValue<'_>,
     ) -> Result<T, SlashArgError> {
@@ -134,8 +134,8 @@ macro_rules! impl_for_integer {
     ($($t:ty)*) => { $(
         #[async_trait::async_trait]
         impl SlashArgument for $t {
-            async fn extract(
-                _: &serenity::Context,
+            async fn extract<U: Send + Sync + 'static>(
+                _: &serenity::Context<U>,
                 _: &serenity::CommandInteraction,
                 value: &serenity::ResolvedValue<'_>,
             ) -> Result<$t, SlashArgError> {
@@ -165,9 +165,9 @@ macro_rules! impl_for_float {
     ($($t:ty)*) => { $(
         #[async_trait::async_trait]
         impl SlashArgumentHack<$t> for &PhantomData<$t> {
-            async fn extract(
+            async fn extract<U: Send + Sync + 'static>(
                 self,
-                _: &serenity::Context,
+                _: &serenity::Context<U>,
                 _: &serenity::CommandInteraction,
                 value: &serenity::ResolvedValue<'_>,
             ) -> Result<$t, SlashArgError> {
@@ -187,9 +187,9 @@ impl_for_float!(f32 f64);
 
 #[async_trait::async_trait]
 impl SlashArgumentHack<bool> for &PhantomData<bool> {
-    async fn extract(
+    async fn extract<U: Send + Sync + 'static>(
         self,
-        _: &serenity::Context,
+        _: &serenity::Context<U>,
         _: &serenity::CommandInteraction,
         value: &serenity::ResolvedValue<'_>,
     ) -> Result<bool, SlashArgError> {
@@ -208,9 +208,9 @@ impl SlashArgumentHack<bool> for &PhantomData<bool> {
 
 #[async_trait::async_trait]
 impl SlashArgumentHack<serenity::Attachment> for &PhantomData<serenity::Attachment> {
-    async fn extract(
+    async fn extract<U: Send + Sync + 'static>(
         self,
-        _: &serenity::Context,
+        _: &serenity::Context<U>,
         interaction: &serenity::CommandInteraction,
         value: &serenity::ResolvedValue<'_>,
     ) -> Result<serenity::Attachment, SlashArgError> {
@@ -246,9 +246,9 @@ impl SlashArgumentHack<serenity::Attachment> for &PhantomData<serenity::Attachme
 
 #[async_trait::async_trait]
 impl<T: SlashArgument + Sync> SlashArgumentHack<T> for &PhantomData<T> {
-    async fn extract(
+    async fn extract<U: Send + Sync + 'static>(
         self,
-        ctx: &serenity::Context,
+        ctx: &serenity::Context<U>,
         interaction: &serenity::CommandInteraction,
         value: &serenity::ResolvedValue<'_>,
     ) -> Result<T, SlashArgError> {
@@ -269,8 +269,8 @@ macro_rules! impl_slash_argument {
     ($type:ty, $slash_param_type:ident) => {
         #[async_trait::async_trait]
         impl SlashArgument for $type {
-            async fn extract(
-                ctx: &serenity::Context,
+            async fn extract<U: Send + Sync + 'static>(
+                ctx: &serenity::Context<U>,
                 interaction: &serenity::CommandInteraction,
                 value: &serenity::ResolvedValue<'_>,
             ) -> Result<$type, SlashArgError> {

--- a/src/structs/command.rs
+++ b/src/structs/command.rs
@@ -6,7 +6,7 @@ use crate::{serenity_prelude as serenity, BoxFuture};
 /// prefix and application commands
 #[derive(derivative::Derivative)]
 #[derivative(Default(bound = ""), Debug(bound = ""))]
-pub struct Command<U, E> {
+pub struct Command<U: Send + Sync + 'static, E> {
     // =============
     /// Callback to execute when this command is invoked in a prefix context
     #[derivative(Debug = "ignore")]
@@ -128,14 +128,14 @@ pub struct Command<U, E> {
     pub __non_exhaustive: (),
 }
 
-impl<U, E> PartialEq for Command<U, E> {
+impl<U: Send + Sync + 'static, E> PartialEq for Command<U, E> {
     fn eq(&self, other: &Self) -> bool {
         std::ptr::eq(self, other)
     }
 }
-impl<U, E> Eq for Command<U, E> {}
+impl<U: Send + Sync + 'static, E> Eq for Command<U, E> {}
 
-impl<U, E> Command<U, E> {
+impl<U: Send + Sync + 'static, E> Command<U, E> {
     /// Serializes this Command into an application command option, which is the form which Discord
     /// requires subcommands to be in
     fn create_as_subcommand(&self) -> Option<serenity::CreateCommandOption> {

--- a/src/structs/slash.rs
+++ b/src/structs/slash.rs
@@ -14,10 +14,10 @@ pub enum CommandInteractionType {
 /// Application command specific context passed to command invocations.
 #[derive(derivative::Derivative)]
 #[derivative(Debug(bound = ""))]
-pub struct ApplicationContext<'a, U, E> {
+pub struct ApplicationContext<'a, U: Send + Sync + 'static, E> {
     /// Serenity's context, like HTTP or cache
     #[derivative(Debug = "ignore")]
-    pub serenity_context: &'a serenity::Context,
+    pub serenity_context: &'a serenity::Context<U>,
     /// The interaction which triggered this command execution.
     pub interaction: &'a serenity::CommandInteraction,
     /// The type of the interaction which triggered this command execution.
@@ -41,28 +41,24 @@ pub struct ApplicationContext<'a, U, E> {
     pub parent_commands: &'a [&'a crate::Command<U, E>],
     /// The command object which is the current command
     pub command: &'a crate::Command<U, E>,
-    /// Your custom user data
-    // TODO: redundant with framework
-    #[derivative(Debug = "ignore")]
-    pub data: &'a U,
     /// Custom user data carried across a single command invocation
     pub invocation_data: &'a tokio::sync::Mutex<Box<dyn std::any::Any + Send + Sync>>,
     // #[non_exhaustive] forbids struct update syntax for ?? reason
     #[doc(hidden)]
     pub __non_exhaustive: (),
 }
-impl<U, E> Clone for ApplicationContext<'_, U, E> {
+impl<U: Send + Sync + 'static, E> Clone for ApplicationContext<'_, U, E> {
     fn clone(&self) -> Self {
         *self
     }
 }
-impl<U, E> Copy for ApplicationContext<'_, U, E> {}
-impl<U, E> crate::_GetGenerics for ApplicationContext<'_, U, E> {
+impl<U: Send + Sync + 'static, E> Copy for ApplicationContext<'_, U, E> {}
+impl<U: Send + Sync + 'static, E> crate::_GetGenerics for ApplicationContext<'_, U, E> {
     type U = U;
     type E = E;
 }
 
-impl<U, E> ApplicationContext<'_, U, E> {
+impl<U: Send + Sync + 'static, E> ApplicationContext<'_, U, E> {
     /// See [`crate::Context::defer()`]
     pub async fn defer_response(&self, ephemeral: bool) -> Result<(), serenity::Error> {
         if !self
@@ -87,7 +83,7 @@ impl<U, E> ApplicationContext<'_, U, E> {
 /// Possible actions that a context menu entry can have
 #[derive(derivative::Derivative)]
 #[derivative(Debug(bound = ""))]
-pub enum ContextMenuCommandAction<U, E> {
+pub enum ContextMenuCommandAction<U: Send + Sync + 'static, E> {
     /// Context menu entry on a user
     User(
         #[derivative(Debug = "ignore")]
@@ -107,8 +103,8 @@ pub enum ContextMenuCommandAction<U, E> {
     #[doc(hidden)]
     __NonExhaustive,
 }
-impl<U, E> Copy for ContextMenuCommandAction<U, E> {}
-impl<U, E> Clone for ContextMenuCommandAction<U, E> {
+impl<U: Send + Sync + 'static, E> Copy for ContextMenuCommandAction<U, E> {}
+impl<U: Send + Sync + 'static, E> Clone for ContextMenuCommandAction<U, E> {
     fn clone(&self) -> Self {
         *self
     }
@@ -128,7 +124,7 @@ pub struct CommandParameterChoice {
 /// A single parameter of a [`crate::Command`]
 #[derive(Clone, derivative::Derivative)]
 #[derivative(Debug(bound = ""))]
-pub struct CommandParameter<U, E> {
+pub struct CommandParameter<U: Send + Sync + 'static, E> {
     /// Name of this command parameter
     pub name: String,
     /// Localized names with locale string as the key (slash-only)
@@ -173,7 +169,7 @@ pub struct CommandParameter<U, E> {
     pub __non_exhaustive: (),
 }
 
-impl<U, E> CommandParameter<U, E> {
+impl<U: Send + Sync + 'static, E> CommandParameter<U, E> {
     /// Generates a slash command parameter builder from this [`CommandParameter`] instance. This
     /// can be used to register the command on Discord's servers
     pub fn create_as_slash_command_option(&self) -> Option<serenity::CreateCommandOption> {


### PR DESCRIPTION
This is a port of poise to support the rework made in https://github.com/serenity-rs/serenity/pull/2631.

Gets rid of poise's own global data store, moving it into serenity entirely. See the linked PR for more information.