### PR TITLE
implement `pretty_help`

### DIFF
--- a/examples/feature_showcase/builtins.rs
+++ b/examples/feature_showcase/builtins.rs
@@ -19,7 +19,7 @@ pub async fn help(ctx: Context<'_>, command: Option<String>) -> Result<(), Error
 
 #[poise::command(slash_command, prefix_command)]
 pub async fn pretty_help(ctx: Context<'_>, command: Option<String>) -> Result<(), Error> {
-    let configuration = poise::builtins::HelpConfiguration {
+    let configuration = poise::builtins::PrettyHelpConfiguration {
         // [configure aspects about the help message here]
         ..Default::default()
     };

--- a/examples/feature_showcase/builtins.rs
+++ b/examples/feature_showcase/builtins.rs
@@ -16,3 +16,13 @@ pub async fn help(ctx: Context<'_>, command: Option<String>) -> Result<(), Error
     poise::builtins::help(ctx, command.as_deref(), configuration).await?;
     Ok(())
 }
+
+#[poise::command(slash_command, prefix_command)]
+pub async fn pretty_help(ctx: Context<'_>, command: Option<String>) -> Result<(), Error> {
+    let configuration = poise::builtins::HelpConfiguration {
+        // [configure aspects about the help message here]
+        ..Default::default()
+    };
+    poise::builtins::pretty_help(ctx, command.as_deref(), configuration).await?;
+    Ok(())
+}

--- a/examples/feature_showcase/main.rs
+++ b/examples/feature_showcase/main.rs
@@ -40,6 +40,7 @@ async fn main() {
                 #[cfg(feature = "cache")]
                 builtins::servers(),
                 builtins::help(),
+                builtins::pretty_help(),
                 checks::shutdown(),
                 checks::modonly(),
                 checks::delete(),

--- a/src/builtins/help.rs
+++ b/src/builtins/help.rs
@@ -85,7 +85,7 @@ impl TwoColumnList {
 }
 
 /// Get the prefix from options
-async fn get_prefix_from_options<U, E>(ctx: crate::Context<'_, U, E>) -> Option<String> {
+pub(super) async fn get_prefix_from_options<U, E>(ctx: crate::Context<'_, U, E>) -> Option<String> {
     let options = &ctx.framework().options().prefix_options;
     match &options.prefix {
         Some(fixed_prefix) => Some(fixed_prefix.clone()),

--- a/src/builtins/help.rs
+++ b/src/builtins/help.rs
@@ -127,28 +127,22 @@ async fn help_single_command<U, E>(
 ) -> Result<(), serenity::Error> {
     let commands = &ctx.framework().options().commands;
     // Try interpret the command name as a context menu command first
-    let command = commands
-        .iter()
-        .find(|cmd| {
-            cmd.context_menu_name
-                .as_deref()
-                .is_some_and(|n| n.eq_ignore_ascii_case(command_name))
-        })
-        // Then interpret command name as a normal command (possibly nested subcommand)
-        .or(crate::find_command(commands, command_name, true, &mut vec![]).map(|(c, _, _)| c));
+    let mut command = commands.iter().find(|command| {
+        if let Some(context_menu_name) = &command.context_menu_name {
+            if context_menu_name.eq_ignore_ascii_case(command_name) {
+                return true;
+            }
+        }
+        false
+    });
+    // Then interpret command name as a normal command (possibly nested subcommand)
+    if command.is_none() {
+        if let Some((c, _, _)) = crate::find_command(commands, command_name, true, &mut vec![]) {
+            command = Some(c);
+        }
+    }
 
-    let Some(command) = command else {
-        ctx.send(
-            CreateReply::default()
-                .content(format!("No such command `{}`", command_name))
-                .ephemeral(config.ephemeral),
-        )
-        .await?;
-
-        return Ok(());
-    };
-
-    let reply = {
+    let reply = if let Some(command) = command {
         let mut invocations = Vec::new();
         let mut subprefix = None;
         if command.slash_action.is_some() {
@@ -156,19 +150,24 @@ async fn help_single_command<U, E>(
             subprefix = Some(format!("  /{}", command.name));
         }
         if command.prefix_action.is_some() {
-            let prefix = super::help::get_prefix_from_options(ctx)
-                .await
-                // None can happen if the prefix is dynamic, and the callback fails
-                // due to help being invoked with slash or context menu commands.
-                // there might be a better way to handle this.
-                .unwrap_or_else(|| String::from("<prefix>"));
+            let prefix = match get_prefix_from_options(ctx).await {
+                Some(prefix) => prefix,
+                // None can happen if the prefix is dynamic, and the callback
+                // fails due to help being invoked with slash or context menu
+                // commands. Not sure there's a better way to handle this.
+                None => String::from("<prefix>"),
+            };
             invocations.push(format!("`{}{}`", prefix, command.name));
-            subprefix = subprefix.or(Some(format!("  {}{}", prefix, command.name)));
+            if subprefix.is_none() {
+                subprefix = Some(format!("  {}{}", prefix, command.name));
+            }
         }
         if command.context_menu_name.is_some() && command.context_menu_action.is_some() {
             // Since command.context_menu_action is Some, this unwrap is safe
             invocations.push(format_context_menu_name(command).unwrap());
-            subprefix = subprefix.or(Some(String::from("  ")));
+            if subprefix.is_none() {
+                subprefix = Some(String::from("  "));
+            }
         }
         // At least one of the three if blocks should have triggered
         assert!(subprefix.is_some());
@@ -176,11 +175,15 @@ async fn help_single_command<U, E>(
         let invocations = invocations.join("\n");
 
         let mut text = match (&command.description, &command.help_text) {
-            (Some(description), Some(help_text)) if config.include_description => {
-                format!("{}\n\n{}", description, help_text)
+            (Some(description), Some(help_text)) => {
+                if config.include_description {
+                    format!("{}\n\n{}", description, help_text)
+                } else {
+                    help_text.clone()
+                }
             }
-            (_, Some(help_text)) => help_text.clone(),
-            (Some(description), None) => description.clone(),
+            (Some(description), None) => description.to_owned(),
+            (None, Some(help_text)) => help_text.clone(),
             (None, None) => "No help available".to_string(),
         };
         if !command.parameters.is_empty() {
@@ -218,6 +221,8 @@ async fn help_single_command<U, E>(
             text += "```";
         }
         format!("**{}**\n\n{}", invocations, text)
+    } else {
+        format!("No such command `{}`", command_name)
     };
 
     let reply = CreateReply::default()

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -6,6 +6,9 @@
 mod help;
 pub use help::*;
 
+ mod pretty_help;
+ pub use pretty_help::*;
+
 mod register;
 pub use register::*;
 

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -6,8 +6,8 @@
 mod help;
 pub use help::*;
 
- mod pretty_help;
- pub use pretty_help::*;
+mod pretty_help;
+pub use pretty_help::*;
 
 mod register;
 pub use register::*;

--- a/src/builtins/pretty_help.rs
+++ b/src/builtins/pretty_help.rs
@@ -105,6 +105,9 @@ async fn pretty_help_all_commands<U, E>(
                     }
                 }
             }
+            if let Some((i, _)) = buffer.char_indices().nth(1024) {
+                buffer.truncate(i);
+            }
             (category.unwrap_or_default(), buffer, false)
         })
         .collect::<Vec<_>>();

--- a/src/builtins/pretty_help.rs
+++ b/src/builtins/pretty_help.rs
@@ -16,6 +16,8 @@ pub struct PrettyHelpConfiguration<'a> {
     pub show_subcommands: bool,
     /// Whether to include [`crate::Command::description`] (above [`crate::Command::help_text`]).
     pub include_description: bool,
+    /// Color of the Embed
+    pub color: (u8,u8,u8),
     #[doc(hidden)]
     pub __non_exhaustive: (),
 }
@@ -28,6 +30,7 @@ impl Default for PrettyHelpConfiguration<'_> {
             show_context_menu_commands: false,
             show_subcommands: false,
             include_description: true,
+            color: (0, 110, 51),
             __non_exhaustive: (),
         }
     }
@@ -83,7 +86,7 @@ async fn pretty_help_all_commands<U, E>(
                 if let Some(description) = cmd.description.as_deref() {
                     writeln!(buffer, "{}{}`: *{}*", prefix, name, description).ok();
                 } else {
-                    writeln!(buffer, "> {}{}`.", prefix, name).ok();
+                    writeln!(buffer, "{}{}`.", prefix, name).ok();
                 }
 
                 if config.show_subcommands {
@@ -109,7 +112,7 @@ async fn pretty_help_all_commands<U, E>(
     let embed = serenity::CreateEmbed::new()
         .title("Help")
         .fields(fields)
-        .color((0, 110, 51))
+        .color(config.color)
         .footer(serenity::CreateEmbedFooter::new(
             config.extra_text_at_bottom,
         ));

--- a/src/builtins/pretty_help.rs
+++ b/src/builtins/pretty_help.rs
@@ -1,15 +1,31 @@
 //! Contains a built-in help command and surrounding infrastructure that uses embeds.
 
-use super::help::HelpConfiguration;
 use crate::{serenity_prelude as serenity, CreateReply};
 use std::fmt::Write as _;
+
+/// Optional configuration for how the help message from [`pretty_help()`] looks
+pub struct PrettyHelpConfiguration<'a> {
+    /// Extra text displayed at the bottom of your message. Can be used for help and tips specific
+    /// to your bot
+    pub extra_text_at_bottom: &'a str,
+    /// Whether to make the response ephemeral if possible. Can be nice to reduce clutter
+    pub ephemeral: bool,
+    /// Whether to list context menu commands as well
+    pub show_context_menu_commands: bool,
+    /// Whether to list context menu commands as well
+    pub show_subcommands: bool,
+    /// Whether to include [`crate::Command::description`] (above [`crate::Command::help_text`]).
+    pub include_description: bool,
+    #[doc(hidden)]
+    pub __non_exhaustive: (),
+}
 
 /// A help command that works similarly to `builtin::help` butt outputs text in an embed.
 ///
 pub async fn pretty_help<U, E>(
     ctx: crate::Context<'_, U, E>,
     command: Option<&str>,
-    config: HelpConfiguration<'_>,
+    config: PrettyHelpConfiguration<'_>,
 ) -> Result<(), serenity::Error> {
     match command {
         Some(command) => pretty_help_single_command(ctx, command, config).await,
@@ -20,7 +36,7 @@ pub async fn pretty_help<U, E>(
 /// Printing an overview of all commands (e.g. `~help`)
 async fn pretty_help_all_commands<U, E>(
     ctx: crate::Context<'_, U, E>,
-    config: HelpConfiguration<'_>,
+    config: PrettyHelpConfiguration<'_>,
 ) -> Result<(), serenity::Error> {
     let mut categories = crate::util::OrderedMap::new();
     let commands = ctx.framework().options().commands.iter().filter(|cmd| {
@@ -120,7 +136,7 @@ fn format_cmd_prefix<U, E>(cmd: &crate::Command<U, E>, options_prefix: &Option<S
 async fn pretty_help_single_command<U, E>(
     ctx: crate::Context<'_, U, E>,
     command_name: &str,
-    config: HelpConfiguration<'_>,
+    config: PrettyHelpConfiguration<'_>,
 ) -> Result<(), serenity::Error> {
     let commands = &ctx.framework().options().commands;
 

--- a/src/builtins/pretty_help.rs
+++ b/src/builtins/pretty_help.rs
@@ -1,5 +1,6 @@
-use super::help::HelpConfiguration;
+//! Contains a built-in help command and surrounding infrastructure that uses embeds.
 
+use super::help::HelpConfiguration;
 use crate::{serenity_prelude as serenity, CreateReply};
 use std::fmt::Write as _;
 
@@ -11,11 +12,12 @@ pub async fn pretty_help<U, E>(
     config: HelpConfiguration<'_>,
 ) -> Result<(), serenity::Error> {
     match command {
-        Some(command) => help_single_command(ctx, command, config).await,
+        Some(command) => pretty_help_single_command(ctx, command, config).await,
         None => pretty_help_all_commands(ctx, config).await,
     }
 }
 
+/// Printing an overview of all commands (e.g. `~help`)
 async fn pretty_help_all_commands<U, E>(
     ctx: crate::Context<'_, U, E>,
     config: HelpConfiguration<'_>,
@@ -49,9 +51,9 @@ async fn pretty_help_all_commands<U, E>(
                 let name = cmd.context_menu_name.as_deref().unwrap_or(&cmd.name);
                 let prefix = format_cmd_prefix(cmd, &options_prefix);
 
-                write!(
+                writeln!(
                     buffer,
-                    "{}{}`: _{}_\n",
+                    "{}{}`: _{}_",
                     prefix,
                     name,
                     cmd.description.as_deref().unwrap_or_default()
@@ -63,9 +65,9 @@ async fn pretty_help_all_commands<U, E>(
                         let name = sbcmd.context_menu_name.as_deref().unwrap_or(&sbcmd.name);
                         let prefix = format_cmd_prefix(sbcmd, &options_prefix);
 
-                        write!(
+                        writeln!(
                             buffer,
-                            "> {}{}`: _{}_\n",
+                            "> {}{}`: _{}_",
                             prefix,
                             name,
                             sbcmd.description.as_deref().unwrap_or_default()
@@ -95,6 +97,7 @@ async fn pretty_help_all_commands<U, E>(
     Ok(())
 }
 
+/// Figures out which prefix a command should have
 fn format_cmd_prefix<U, E>(cmd: &crate::Command<U, E>, options_prefix: &Option<String>) -> String {
     if cmd.slash_action.is_some() {
         "`/".into()
@@ -143,293 +146,101 @@ async fn pretty_help_single_command<U, E>(
         return Ok(());
     };
 
-    let reply = {
-        let mut invocations = Vec::new();
-        let mut subprefix = None;
-        if command.slash_action.is_some() {
-            invocations.push(format!("`/{}`", command.name));
-            subprefix = Some(format!("> /{}", command.name));
-        }
-        if command.prefix_action.is_some() {
-            let prefix = super::help::get_prefix_from_options(ctx)
-                .await
-                // This can happen if the prefix is dynamic, and the callback fails
-                // due to help being invoked with slash or context menu commands.
-                .unwrap_or_else(|| String::from("<prefix>"));
-            invocations.push(format!("`{}{}`", prefix, command.name));
-            subprefix = subprefix.or(Some(format!("> {}{}", prefix, command.name)));
-        }
-        if command.context_menu_name.is_some() && command.context_menu_action.is_some() {
-            // Since command.context_menu_action is Some, this unwrap is safe
-            invocations.push(format_context_menu_name(command).unwrap());
-            subprefix = subprefix.or(Some(String::from("> ")));
-        }
-        // At least one of the three if blocks should have triggered
-        assert!(!invocations.is_empty());
-        assert!(subprefix.is_some());
+    let mut invocations = Vec::new();
+    let mut subprefix = None;
 
-        let invocations = invocations.join("\n");
-        let subprefix = subprefix.unwrap();
-
-        let mut description = match (&command.description, &command.help_text) {
-            (Some(description), Some(help_text)) if config.include_description => {
-                format!("{}\n\n{}", description, help_text)
-            }
-            (_, Some(help_text)) => help_text.clone(),
-            (Some(description), None) => description.clone(),
-            (None, None) => "No help available".to_string(),
+    if command.slash_action.is_some() {
+        invocations.push(format!("`/{}`", command.name));
+        subprefix = Some(format!("> /{}", command.name));
+    }
+    if command.prefix_action.is_some() {
+        let prefix = super::help::get_prefix_from_options(ctx)
+            .await
+            // This can happen if the prefix is dynamic, and the callback fails
+            // due to help being invoked with slash or context menu commands.
+            .unwrap_or_else(|| String::from("<prefix>"));
+        invocations.push(format!("`{}{}`", prefix, command.name));
+        subprefix = subprefix.or(Some(format!("> {}{}", prefix, command.name)));
+    }
+    if command.context_menu_name.is_some() && command.context_menu_action.is_some() {
+        let kind = match command.context_menu_action {
+            Some(crate::ContextMenuCommandAction::User(_)) => "user",
+            Some(crate::ContextMenuCommandAction::Message(_)) => "message",
+            Some(crate::ContextMenuCommandAction::__NonExhaustive) | None => unreachable!(),
         };
+        invocations.push(format!(
+            "{} (on {})",
+            command
+                .context_menu_name
+                .as_deref()
+                .unwrap_or(&command.name),
+            kind
+        ));
+        subprefix = subprefix.or(Some(String::from("> ")));
+    }
+    // At least one of the three if blocks should have triggered
+    assert!(!invocations.is_empty());
+    assert!(subprefix.is_some());
 
-        //
-        // TODO
-        //
+    let invocations = invocations
+        .into_iter()
+        .reduce(|x, y| format!("{x}\n{y}"))
+        .map(|s| ("", s, false));
 
-        if !command.parameters.is_empty() {
-            description += "\n\n```\nParameters:\n";
-            let mut parameterlist = TwoColumnList::new();
-            for parameter in &command.parameters {
-                let name = parameter.name.clone();
-                let description = parameter.description.as_deref().unwrap_or("");
-                let description = format!(
-                    "({}) {}",
-                    if parameter.required {
-                        "required"
-                    } else {
-                        "optional"
-                    },
-                    description,
-                );
-                parameterlist.push_two_colums(name, description);
-            }
-            description += &parameterlist.into_string();
-            description += "```";
+    let description = match (&command.description, &command.help_text) {
+        (Some(description), Some(help_text)) if config.include_description => {
+            format!("{}\n\n{}", description, help_text)
         }
-        if !command.subcommands.is_empty() {
-            description += "\n\n```\nSubcommands:\n";
-            let mut commandlist = TwoColumnList::new();
-            // Subcommands can exist on context menu commands, but there's no
-            // hierarchy in the menu, so just display them as a list without
-            // subprefix.
-            preformat_subcommands(&mut commandlist, command, &subprefix);
-            description += &commandlist.into_string();
-            description += "```";
-        }
-        format!("**{}**\n\n{}", invocations, description)
+        (_, Some(help_text)) => help_text.clone(),
+        (Some(description), None) => description.clone(),
+        (None, None) => "No help available".to_string(),
     };
 
+    let parameters = command
+        .parameters
+        .iter()
+        .map(|parameter| {
+            format!(
+                "`{}` ({}) _{}_.",
+                parameter.name,
+                if parameter.required {
+                    "required"
+                } else {
+                    "optional"
+                },
+                parameter.description.as_deref().unwrap_or_default(),
+            )
+        })
+        .reduce(|x, y| format!("{x}\n{y}"))
+        .map(|s| ("Parameters", s, false));
+
+    let sbcmds = command
+        .subcommands
+        .iter()
+        .map(|sbcmd| {
+            format!(
+                "> {}{}`: _{}_",
+                format_cmd_prefix(sbcmd, &subprefix), // i have no idea about this really
+                sbcmd.context_menu_name.as_deref().unwrap_or(&sbcmd.name),
+                sbcmd.description.as_deref().unwrap_or_default()
+            )
+        })
+        .reduce(|x, y| format!("{x}\n{y}"))
+        .map(|s| ("Subcommands", s, false));
+
+    let fields = invocations
+        .into_iter()
+        .chain(parameters.into_iter())
+        .chain(sbcmds.into_iter());
+
+    let embed = serenity::CreateEmbed::default()
+        .description(description)
+        .fields(fields);
+
     let reply = CreateReply::default()
-        .content(reply)
+        .embed(embed)
         .ephemeral(config.ephemeral);
 
     ctx.send(reply).await?;
     Ok(())
-}
-
-/// Convenience function to align descriptions behind commands
-struct TwoColumnList(Vec<(String, Option<String>)>);
-
-#[allow(unused)]
-impl TwoColumnList {
-    /// Creates a new [`TwoColumnList`]
-    fn new() -> Self {
-        Self(Vec::new())
-    }
-
-    /// Add a line that needs the padding between the columns
-    fn push_two_colums(&mut self, command: String, description: String) {
-        self.0.push((command, Some(description)));
-    }
-
-    /// Add a line that doesn't influence the first columns's width
-    fn push_heading(&mut self, category: &str) {
-        if !self.0.is_empty() {
-            self.0.push(("".to_string(), None));
-        }
-        let mut category = category.to_string();
-        category += ":";
-        self.0.push((category, None));
-    }
-
-    /// Convert the list into a string with aligned descriptions
-    fn into_string(self) -> String {
-        let longest_command = self
-            .0
-            .iter()
-            .filter_map(|(command, description)| {
-                if description.is_some() {
-                    Some(command.len())
-                } else {
-                    None
-                }
-            })
-            .max()
-            .unwrap_or(0);
-        let mut text = String::new();
-        for (command, description) in self.0 {
-            if let Some(description) = description {
-                let padding = " ".repeat(longest_command - command.len() + 3);
-                writeln!(text, "{}{}{}", command, padding, description).unwrap();
-            } else {
-                writeln!(text, "{}", command).unwrap();
-            }
-        }
-        text
-    }
-}
-
-/// Format context menu command name
-fn format_context_menu_name<U, E>(command: &crate::Command<U, E>) -> Option<String> {
-    let kind = match command.context_menu_action {
-        Some(crate::ContextMenuCommandAction::User(_)) => "user",
-        Some(crate::ContextMenuCommandAction::Message(_)) => "message",
-        Some(crate::ContextMenuCommandAction::__NonExhaustive) => unreachable!(),
-        None => return None,
-    };
-    Some(format!(
-        "{} (on {})",
-        command
-            .context_menu_name
-            .as_deref()
-            .unwrap_or(&command.name),
-        kind
-    ))
-}
-
-/// Code for printing help of a specific command (e.g. `~help my_command`)
-async fn help_single_command<U, E>(
-    ctx: crate::Context<'_, U, E>,
-    command_name: &str,
-    config: HelpConfiguration<'_>,
-) -> Result<(), serenity::Error> {
-    let commands = &ctx.framework().options().commands;
-    // Try interpret the command name as a context menu command first
-    let mut command = commands.iter().find(|command| {
-        if let Some(context_menu_name) = &command.context_menu_name {
-            if context_menu_name.eq_ignore_ascii_case(command_name) {
-                return true;
-            }
-        }
-        false
-    });
-    // Then interpret command name as a normal command (possibly nested subcommand)
-    if command.is_none() {
-        if let Some((c, _, _)) = crate::find_command(commands, command_name, true, &mut vec![]) {
-            command = Some(c);
-        }
-    }
-
-    let reply = if let Some(command) = command {
-        let mut invocations = Vec::new();
-        let mut subprefix = None;
-        if command.slash_action.is_some() {
-            invocations.push(format!("`/{}`", command.name));
-            subprefix = Some(format!("  /{}", command.name));
-        }
-        if command.prefix_action.is_some() {
-            let prefix = match super::help::get_prefix_from_options(ctx).await {
-                Some(prefix) => prefix,
-                // None can happen if the prefix is dynamic, and the callback
-                // fails due to help being invoked with slash or context menu
-                // commands. Not sure there's a better way to handle this.
-                None => String::from("<prefix>"),
-            };
-            invocations.push(format!("`{}{}`", prefix, command.name));
-            if subprefix.is_none() {
-                subprefix = Some(format!("  {}{}", prefix, command.name));
-            }
-        }
-        if command.context_menu_name.is_some() && command.context_menu_action.is_some() {
-            // Since command.context_menu_action is Some, this unwrap is safe
-            invocations.push(format_context_menu_name(command).unwrap());
-            if subprefix.is_none() {
-                subprefix = Some(String::from("  "));
-            }
-        }
-        // At least one of the three if blocks should have triggered
-        assert!(subprefix.is_some());
-        assert!(!invocations.is_empty());
-        let invocations = invocations.join("\n");
-
-        let mut text = match (&command.description, &command.help_text) {
-            (Some(description), Some(help_text)) => {
-                if config.include_description {
-                    format!("{}\n\n{}", description, help_text)
-                } else {
-                    help_text.clone()
-                }
-            }
-            (Some(description), None) => description.to_owned(),
-            (None, Some(help_text)) => help_text.clone(),
-            (None, None) => "No help available".to_string(),
-        };
-        if !command.parameters.is_empty() {
-            text += "\n\n```\nParameters:\n";
-            let mut parameterlist = TwoColumnList::new();
-            for parameter in &command.parameters {
-                let name = parameter.name.clone();
-                let description = parameter.description.as_deref().unwrap_or("");
-                let description = format!(
-                    "({}) {}",
-                    if parameter.required {
-                        "required"
-                    } else {
-                        "optional"
-                    },
-                    description,
-                );
-                parameterlist.push_two_colums(name, description);
-            }
-            text += &parameterlist.into_string();
-            text += "```";
-        }
-        if !command.subcommands.is_empty() {
-            text += "\n\n```\nSubcommands:\n";
-            let mut commandlist = TwoColumnList::new();
-            // Subcommands can exist on context menu commands, but there's no
-            // hierarchy in the menu, so just display them as a list without
-            // subprefix.
-            preformat_subcommands(
-                &mut commandlist,
-                command,
-                &subprefix.unwrap_or_else(|| String::from("  ")),
-            );
-            text += &commandlist.into_string();
-            text += "```";
-        }
-        format!("**{}**\n\n{}", invocations, text)
-    } else {
-        format!("No such command `{}`", command_name)
-    };
-
-    let reply = CreateReply::default()
-        .content(reply)
-        .ephemeral(config.ephemeral);
-
-    ctx.send(reply).await?;
-    Ok(())
-}
-
-/// Recursively formats all subcommands
-fn preformat_subcommands<U, E>(
-    commands: &mut TwoColumnList,
-    command: &crate::Command<U, E>,
-    prefix: &str,
-) {
-    let as_context_command = command.slash_action.is_none() && command.prefix_action.is_none();
-    for subcommand in &command.subcommands {
-        let command = if as_context_command {
-            let name = format_context_menu_name(subcommand);
-            if name.is_none() {
-                continue;
-            };
-            name.unwrap()
-        } else {
-            format!("{} {}", prefix, subcommand.name)
-        };
-        let description = subcommand.description.as_deref().unwrap_or("").to_string();
-        commands.push_two_colums(command, description);
-        // We could recurse here, but things can get cluttered quickly.
-        // Instead, we show (using this function) subsubcommands when
-        // the user asks for help on the subcommand.
-    }
 }

--- a/src/builtins/pretty_help.rs
+++ b/src/builtins/pretty_help.rs
@@ -20,6 +20,19 @@ pub struct PrettyHelpConfiguration<'a> {
     pub __non_exhaustive: (),
 }
 
+impl Default for PrettyHelpConfiguration<'_> {
+    fn default() -> Self {
+        Self {
+            extra_text_at_bottom: "",
+            ephemeral: true,
+            show_context_menu_commands: false,
+            show_subcommands: false,
+            include_description: true,
+            __non_exhaustive: (),
+        }
+    }
+}
+
 /// A help command that works similarly to `builtin::help` butt outputs text in an embed.
 ///
 pub async fn pretty_help<U, E>(

--- a/src/builtins/pretty_help.rs
+++ b/src/builtins/pretty_help.rs
@@ -1,0 +1,399 @@
+
+use super::help::HelpConfiguration;
+
+
+use crate::{serenity_prelude as serenity, CreateReply};
+use std::fmt::Write as _;
+
+
+/// Convenience function to align descriptions behind commands
+struct TwoColumnList(Vec<(String, Option<String>)>);
+
+impl TwoColumnList {
+    /// Creates a new [`TwoColumnList`]
+    fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Add a line that needs the padding between the columns
+    fn push_two_colums(&mut self, command: String, description: String) {
+        self.0.push((command, Some(description)));
+    }
+
+    /// Add a line that doesn't influence the first columns's width
+    fn push_heading(&mut self, category: &str) {
+        if !self.0.is_empty() {
+            self.0.push(("".to_string(), None));
+        }
+        let mut category = category.to_string();
+        category += ":";
+        self.0.push((category, None));
+    }
+
+    /// Convert the list into a string with aligned descriptions
+    fn into_string(self) -> String {
+        let longest_command = self
+            .0
+            .iter()
+            .filter_map(|(command, description)| {
+                if description.is_some() {
+                    Some(command.len())
+                } else {
+                    None
+                }
+            })
+            .max()
+            .unwrap_or(0);
+        let mut text = String::new();
+        for (command, description) in self.0 {
+            if let Some(description) = description {
+                let padding = " ".repeat(longest_command - command.len() + 3);
+                writeln!(text, "{}{}{}", command, padding, description).unwrap();
+            } else {
+                writeln!(text, "{}", command).unwrap();
+            }
+        }
+        text
+    }
+}
+
+/// Get the prefix from options
+async fn get_prefix_from_options<U, E>(ctx: crate::Context<'_, U, E>) -> Option<String> {
+    let options = &ctx.framework().options().prefix_options;
+    match &options.prefix {
+        Some(fixed_prefix) => Some(fixed_prefix.clone()),
+        None => match options.dynamic_prefix {
+            Some(dynamic_prefix_callback) => {
+                match dynamic_prefix_callback(crate::PartialContext::from(ctx)).await {
+                    Ok(Some(dynamic_prefix)) => Some(dynamic_prefix),
+                    _ => None,
+                }
+            }
+            None => None,
+        },
+    }
+}
+
+/// Format context menu command name
+fn format_context_menu_name<U, E>(command: &crate::Command<U, E>) -> Option<String> {
+    let kind = match command.context_menu_action {
+        Some(crate::ContextMenuCommandAction::User(_)) => "user",
+        Some(crate::ContextMenuCommandAction::Message(_)) => "message",
+        Some(crate::ContextMenuCommandAction::__NonExhaustive) => unreachable!(),
+        None => return None,
+    };
+    Some(format!(
+        "{} (on {})",
+        command
+            .context_menu_name
+            .as_deref()
+            .unwrap_or(&command.name),
+        kind
+    ))
+}
+
+/// Code for printing help of a specific command (e.g. `~help my_command`)
+async fn help_single_command<U, E>(
+    ctx: crate::Context<'_, U, E>,
+    command_name: &str,
+    config: HelpConfiguration<'_>,
+) -> Result<(), serenity::Error> {
+    let commands = &ctx.framework().options().commands;
+    // Try interpret the command name as a context menu command first
+    let mut command = commands.iter().find(|command| {
+        if let Some(context_menu_name) = &command.context_menu_name {
+            if context_menu_name.eq_ignore_ascii_case(command_name) {
+                return true;
+            }
+        }
+        false
+    });
+    // Then interpret command name as a normal command (possibly nested subcommand)
+    if command.is_none() {
+        if let Some((c, _, _)) = crate::find_command(commands, command_name, true, &mut vec![]) {
+            command = Some(c);
+        }
+    }
+
+    let reply = if let Some(command) = command {
+        let mut invocations = Vec::new();
+        let mut subprefix = None;
+        if command.slash_action.is_some() {
+            invocations.push(format!("`/{}`", command.name));
+            subprefix = Some(format!("  /{}", command.name));
+        }
+        if command.prefix_action.is_some() {
+            let prefix = match get_prefix_from_options(ctx).await {
+                Some(prefix) => prefix,
+                // None can happen if the prefix is dynamic, and the callback
+                // fails due to help being invoked with slash or context menu
+                // commands. Not sure there's a better way to handle this.
+                None => String::from("<prefix>"),
+            };
+            invocations.push(format!("`{}{}`", prefix, command.name));
+            if subprefix.is_none() {
+                subprefix = Some(format!("  {}{}", prefix, command.name));
+            }
+        }
+        if command.context_menu_name.is_some() && command.context_menu_action.is_some() {
+            // Since command.context_menu_action is Some, this unwrap is safe
+            invocations.push(format_context_menu_name(command).unwrap());
+            if subprefix.is_none() {
+                subprefix = Some(String::from("  "));
+            }
+        }
+        // At least one of the three if blocks should have triggered
+        assert!(subprefix.is_some());
+        assert!(!invocations.is_empty());
+        let invocations = invocations.join("\n");
+
+        let mut text = match (&command.description, &command.help_text) {
+            (Some(description), Some(help_text)) => {
+                if config.include_description {
+                    format!("{}\n\n{}", description, help_text)
+                } else {
+                    help_text.clone()
+                }
+            }
+            (Some(description), None) => description.to_owned(),
+            (None, Some(help_text)) => help_text.clone(),
+            (None, None) => "No help available".to_string(),
+        };
+        if !command.parameters.is_empty() {
+            text += "\n\n```\nParameters:\n";
+            let mut parameterlist = TwoColumnList::new();
+            for parameter in &command.parameters {
+                let name = parameter.name.clone();
+                let description = parameter.description.as_deref().unwrap_or("");
+                let description = format!(
+                    "({}) {}",
+                    if parameter.required {
+                        "required"
+                    } else {
+                        "optional"
+                    },
+                    description,
+                );
+                parameterlist.push_two_colums(name, description);
+            }
+            text += &parameterlist.into_string();
+            text += "```";
+        }
+        if !command.subcommands.is_empty() {
+            text += "\n\n```\nSubcommands:\n";
+            let mut commandlist = TwoColumnList::new();
+            // Subcommands can exist on context menu commands, but there's no
+            // hierarchy in the menu, so just display them as a list without
+            // subprefix.
+            preformat_subcommands(
+                &mut commandlist,
+                command,
+                &subprefix.unwrap_or_else(|| String::from("  ")),
+            );
+            text += &commandlist.into_string();
+            text += "```";
+        }
+        format!("**{}**\n\n{}", invocations, text)
+    } else {
+        format!("No such command `{}`", command_name)
+    };
+
+    let reply = CreateReply::default()
+        .content(reply)
+        .ephemeral(config.ephemeral);
+
+    ctx.send(reply).await?;
+    Ok(())
+}
+
+/// Recursively formats all subcommands
+fn preformat_subcommands<U, E>(
+    commands: &mut TwoColumnList,
+    command: &crate::Command<U, E>,
+    prefix: &str,
+) {
+    let as_context_command = command.slash_action.is_none() && command.prefix_action.is_none();
+    for subcommand in &command.subcommands {
+        let command = if as_context_command {
+            let name = format_context_menu_name(subcommand);
+            if name.is_none() {
+                continue;
+            };
+            name.unwrap()
+        } else {
+            format!("{} {}", prefix, subcommand.name)
+        };
+        let description = subcommand.description.as_deref().unwrap_or("").to_string();
+        commands.push_two_colums(command, description);
+        // We could recurse here, but things can get cluttered quickly.
+        // Instead, we show (using this function) subsubcommands when
+        // the user asks for help on the subcommand.
+    }
+}
+
+/// Preformat lines (except for padding,) like `("  /ping", "Emits a ping message")`
+fn preformat_command<U, E>(
+    commands: &mut TwoColumnList,
+    config: &HelpConfiguration<'_>,
+    command: &crate::Command<U, E>,
+    indent: &str,
+    options_prefix: Option<&str>,
+) {
+    let prefix = if command.slash_action.is_some() {
+        String::from("/")
+    } else if command.prefix_action.is_some() {
+        options_prefix.map(String::from).unwrap_or_default()
+    } else {
+        // This is not a prefix or slash command, i.e. probably a context menu only command
+        // This should have been filtered out in `generate_all_commands`
+        unreachable!();
+    };
+
+    let prefix = format!("{}{}{}", indent, prefix, command.name);
+    commands.push_two_colums(
+        prefix.clone(),
+        command.description.as_deref().unwrap_or("").to_string(),
+    );
+    if config.show_subcommands {
+        preformat_subcommands(commands, command, &prefix)
+    }
+}
+
+/// Create help text for `help_all_commands`
+///
+/// This is a separate function so we can have tests for it
+async fn generate_all_commands<U, E>(
+    ctx: crate::Context<'_, U, E>,
+    config: &HelpConfiguration<'_>,
+) -> Result<String, serenity::Error> {
+    let mut categories = crate::util::OrderedMap::<Option<&str>, Vec<&crate::Command<U, E>>>::new();
+    for cmd in &ctx.framework().options().commands {
+        categories
+            .get_or_insert_with(cmd.category.as_deref(), Vec::new)
+            .push(cmd);
+    }
+
+    let options_prefix = get_prefix_from_options(ctx).await;
+
+    let mut menu = String::from("```\n");
+
+    let mut commandlist = TwoColumnList::new();
+    for (category_name, commands) in categories {
+        let commands = commands
+            .into_iter()
+            .filter(|cmd| {
+                !cmd.hide_in_help && (cmd.prefix_action.is_some() || cmd.slash_action.is_some())
+            })
+            .collect::<Vec<_>>();
+        if commands.is_empty() {
+            continue;
+        }
+        commandlist.push_heading(category_name.unwrap_or("Commands"));
+        for command in commands {
+            preformat_command(
+                &mut commandlist,
+                config,
+                command,
+                "  ",
+                options_prefix.as_deref(),
+            );
+        }
+    }
+    menu += &commandlist.into_string();
+
+    if config.show_context_menu_commands {
+        menu += "\nContext menu commands:\n";
+
+        for command in &ctx.framework().options().commands {
+            let name = format_context_menu_name(command);
+            if name.is_none() {
+                continue;
+            };
+            let _ = writeln!(menu, "  {}", name.unwrap());
+        }
+    }
+
+    menu += "\n";
+    menu += config.extra_text_at_bottom;
+    menu += "\n```";
+
+    Ok(menu)
+}
+
+/// Code for printing an overview of all commands (e.g. `~help`)
+async fn help_all_commands<U, E>(
+    ctx: crate::Context<'_, U, E>,
+    config: HelpConfiguration<'_>,
+) -> Result<(), serenity::Error> {
+    let menu = generate_all_commands(ctx, &config).await?;
+    let reply = CreateReply::default()
+        .content(menu)
+        .ephemeral(config.ephemeral);
+
+    ctx.send(reply).await?;
+    Ok(())
+}
+
+/// A help command that outputs text in a code block, groups commands by categories, and annotates
+/// commands with a slash if they exist as slash commands.
+///
+/// Example usage from Ferris, the Discord bot running in the Rust community server:
+/// ```rust
+/// # type Error = Box<dyn std::error::Error>;
+/// # type Context<'a> = poise::Context<'a, (), Error>;
+/// /// Show this menu
+/// #[poise::command(prefix_command, track_edits, slash_command)]
+/// pub async fn help(
+///     ctx: Context<'_>,
+///     #[description = "Specific command to show help about"] command: Option<String>,
+/// ) -> Result<(), Error> {
+///     let config = poise::builtins::HelpConfiguration {
+///         extra_text_at_bottom: "\
+/// Type ?help command for more info on a command.
+/// You can edit your message to the bot and the bot will edit its response.",
+///         ..Default::default()
+///     };
+///     poise::builtins::help(ctx, command.as_deref(), config).await?;
+///     Ok(())
+/// }
+/// ```
+/// Output:
+/// ```text
+/// Playground:
+///   ?play        Compile and run Rust code in a playground
+///   ?eval        Evaluate a single Rust expression
+///   ?miri        Run code and detect undefined behavior using Miri
+///   ?expand      Expand macros to their raw desugared form
+///   ?clippy      Catch common mistakes using the Clippy linter
+///   ?fmt         Format code using rustfmt
+///   ?microbench  Benchmark small snippets of code
+///   ?procmacro   Compile and use a procedural macro
+///   ?godbolt     View assembly using Godbolt
+///   ?mca         Run performance analysis using llvm-mca
+///   ?llvmir      View LLVM IR using Godbolt
+/// Crates:
+///   /crate       Lookup crates on crates.io
+///   /doc         Lookup documentation
+/// Moderation:
+///   /cleanup     Deletes the bot's messages for cleanup
+///   /ban         Bans another person
+///   ?move        Move a discussion to another channel
+///   /rustify     Adds the Rustacean role to members
+/// Miscellaneous:
+///   ?go          Evaluates Go code
+///   /source      Links to the bot GitHub repo
+///   /help        Show this menu
+///
+/// Type ?help command for more info on a command.
+/// You can edit your message to the bot and the bot will edit its response.
+/// ```
+pub async fn pretty_help<U, E>(
+    ctx: crate::Context<'_, U, E>,
+    command: Option<&str>,
+    config: HelpConfiguration<'_>,
+) -> Result<(), serenity::Error> {
+    match command {
+        Some(command) => help_single_command(ctx, command, config).await,
+        None => help_all_commands(ctx, config).await,
+    }
+}


### PR DESCRIPTION
Two things are in this PR:

1. Created an alternate help template that uses embeds instead of code blocks. It is not tested yet as I do not have a way to test subcommands. (`pretty_help` reuses an item from the `help` module, so it redeclares it as `pub(super)`)
2. Some reformatting of the `help` module.