### PR TITLE
fix: race condition in use of of atomic variable in example

### DIFF
--- a/examples/event_handler/main.rs
+++ b/examples/event_handler/main.rs
@@ -57,10 +57,12 @@ async fn event_handler(
         }
         serenity::FullEvent::Message { new_message } => {
             if new_message.content.to_lowercase().contains("poise") {
-                let mentions = data.poise_mentions.load(Ordering::SeqCst) + 1;
-                data.poise_mentions.store(mentions, Ordering::SeqCst);
+                let old_mentions = data.poise_mentions.fetch_add(1, Ordering::SeqCst);
                 new_message
-                    .reply(ctx, format!("Poise has been mentioned {} times", mentions))
+                    .reply(
+                        ctx,
+                        format!("Poise has been mentioned {} times", old_mentions + 1),
+                    )
                     .await?;
             }
         }


### PR DESCRIPTION
<!-- base the PR on the current branch, if it has no breaking changes, and on the next branch, if it does -->
Closes: https://github.com/serenity-rs/poise/issues/245#issuecomment-1969520941
I didn't test it yet but the change is pretty small. I will try to test once I get a chance but might be a while so I'm sending the PR still in case someone has a chance before me.