### PR TITLE
Fix bug causing bot to reply to its own messages in event_handler example

### DIFF
--- a/examples/event_handler/main.rs
+++ b/examples/event_handler/main.rs
@@ -56,7 +56,9 @@ async fn event_handler(
             println!("Logged in as {}", data_about_bot.user.name);
         }
         serenity::FullEvent::Message { new_message } => {
-            if new_message.content.to_lowercase().contains("poise") {
+            if new_message.content.to_lowercase().contains("poise")
+                && new_message.author.id != ctx.cache.current_user().id
+            {
                 let old_mentions = data.poise_mentions.fetch_add(1, Ordering::SeqCst);
                 new_message
                     .reply(


### PR DESCRIPTION
In the event_handler example, sending message containing the word "poise" would cause the bot to reply with the message "Poise has been mentioned {n} times" like expected. However, since the bot's message itself contained the word "poise", it would continually reply to itself. 

I fixed it by adding a simple check to test the message_author's id against the bot's user id.
<!-- base the PR on the current branch, if it has no breaking changes, and on the next branch, if it does -->
