### PR TITLE
.unwrap_or_default() instead of falling back to "<prefix>" in single-command help

### DIFF
--- a/src/builtins/help.rs
+++ b/src/builtins/help.rs
@@ -150,7 +150,7 @@ async fn help_single_command<U, E>(
             subprefix = Some(format!("  /{}", command.name));
         }
         if command.prefix_action.is_some() {
-            let prefix = match get_prefix_from_options(ctx).await.unwrap_or_default();
+            let prefix = get_prefix_from_options(ctx).await.unwrap_or_default();
             invocations.push(format!("`{}{}`", prefix, command.name));
             if subprefix.is_none() {
                 subprefix = Some(format!("  {}{}", prefix, command.name));

--- a/src/builtins/help.rs
+++ b/src/builtins/help.rs
@@ -150,13 +150,7 @@ async fn help_single_command<U, E>(
             subprefix = Some(format!("  /{}", command.name));
         }
         if command.prefix_action.is_some() {
-            let prefix = match get_prefix_from_options(ctx).await {
-                Some(prefix) => prefix,
-                // None can happen if the prefix is dynamic, and the callback
-                // fails due to help being invoked with slash or context menu
-                // commands. Not sure there's a better way to handle this.
-                None => String::from("<prefix>"),
-            };
+            let prefix = match get_prefix_from_options(ctx).await.unwrap_or_default();
             invocations.push(format!("`{}{}`", prefix, command.name));
             if subprefix.is_none() {
                 subprefix = Some(format!("  {}{}", prefix, command.name));


### PR DESCRIPTION
fixes #254 