### PR TITLE
Fix usage of additional_prefixes in the example

### DIFF
--- a/examples/basic_structure/main.rs
+++ b/examples/basic_structure/main.rs
@@ -50,8 +50,8 @@ async fn main() {
                 Duration::from_secs(3600),
             ))),
             additional_prefixes: vec![
-                poise::Prefix::Literal("hey bot"),
                 poise::Prefix::Literal("hey bot,"),
+                poise::Prefix::Literal("hey bot"),
             ],
             ..Default::default()
         },


### PR DESCRIPTION
<!-- base the PR on the current branch, if it has no breaking changes, and on the next branch, if it does -->

This did not work for me, the second prefix with the comma would not respond, after a while I came up with an assumption that maybe the first prefix gets matched and instead the comma becomes treated as part of the command name and no command matches, so this is easily fixed by trying to match the longer prefix first.