### PR TITLE
Add support for using manual cooldowns on single commands

### DIFF
--- a/macros/Cargo.lock
+++ b/macros/Cargo.lock
@@ -51,7 +51,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "poise_macros"
-version = "0.5.7"
+version = "0.6.1"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/macros/src/command/mod.rs
+++ b/macros/src/command/mod.rs
@@ -49,7 +49,7 @@ pub struct CommandArgs {
     category: Option<String>,
     custom_data: Option<syn::Expr>,
 
-    manual_cooldowns: bool,
+    manual_cooldowns: Option<bool>,
 
     // In seconds
     global_cooldown: Option<u64>,
@@ -282,7 +282,7 @@ fn generate_command(mut inv: Invocation) -> Result<proc_macro2::TokenStream, dar
     let description = wrap_option_to_string(inv.description.as_ref());
     let category = wrap_option_to_string(inv.args.category.as_ref());
 
-    let manual_cooldowns = inv.args.manual_cooldowns;
+    let manual_cooldowns = wrap_option(inv.args.manual_cooldowns);
     let cooldown_config = generate_cooldown_config(&inv.args);
 
     let default_member_permissions = &inv.default_member_permissions;

--- a/macros/src/command/mod.rs
+++ b/macros/src/command/mod.rs
@@ -49,6 +49,8 @@ pub struct CommandArgs {
     category: Option<String>,
     custom_data: Option<syn::Expr>,
 
+    manual_cooldowns: bool,
+
     // In seconds
     global_cooldown: Option<u64>,
     user_cooldown: Option<u64>,
@@ -280,6 +282,7 @@ fn generate_command(mut inv: Invocation) -> Result<proc_macro2::TokenStream, dar
     let description = wrap_option_to_string(inv.description.as_ref());
     let category = wrap_option_to_string(inv.args.category.as_ref());
 
+    let manual_cooldowns = inv.args.manual_cooldowns;
     let cooldown_config = generate_cooldown_config(&inv.args);
 
     let default_member_permissions = &inv.default_member_permissions;
@@ -354,6 +357,7 @@ fn generate_command(mut inv: Invocation) -> Result<proc_macro2::TokenStream, dar
                 description_localizations: #description_localizations,
                 help_text: #help_text,
                 hide_in_help: #hide_in_help,
+                manual_cooldowns: #manual_cooldowns,
                 cooldowns: std::sync::Mutex::new(::poise::Cooldowns::new()),
                 cooldown_config: #cooldown_config,
                 reuse_response: #reuse_response,

--- a/macros/src/command/prefix.rs
+++ b/macros/src/command/prefix.rs
@@ -63,7 +63,10 @@ pub fn generate_prefix_action(inv: &Invocation) -> Result<proc_macro2::TokenStre
                 error,
             ))?;
 
-            if !ctx.framework.options.manual_cooldowns && !ctx.command.manual_cooldowns {
+            let is_framework_cooldown = !ctx.command.manual_cooldowns
+            .unwrap_or_else(|| ctx.framework.options.manual_cooldowns);
+
+            if is_framework_cooldown {
                 ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());
             }
 

--- a/macros/src/command/prefix.rs
+++ b/macros/src/command/prefix.rs
@@ -63,7 +63,7 @@ pub fn generate_prefix_action(inv: &Invocation) -> Result<proc_macro2::TokenStre
                 error,
             ))?;
 
-            if !ctx.framework.options.manual_cooldowns {
+            if !ctx.framework.options.manual_cooldowns && !ctx.command.manual_cooldowns {
                 ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());
             }
 

--- a/macros/src/command/prefix.rs
+++ b/macros/src/command/prefix.rs
@@ -64,7 +64,7 @@ pub fn generate_prefix_action(inv: &Invocation) -> Result<proc_macro2::TokenStre
             ))?;
 
             let is_framework_cooldown = !ctx.command.manual_cooldowns
-            .unwrap_or_else(|| ctx.framework.options.manual_cooldowns);
+                .unwrap_or_else(|| ctx.framework.options.manual_cooldowns);
 
             if is_framework_cooldown {
                 ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());

--- a/macros/src/command/slash.rs
+++ b/macros/src/command/slash.rs
@@ -185,7 +185,7 @@ pub fn generate_slash_action(inv: &Invocation) -> Result<proc_macro2::TokenStrea
                 #( (#param_names: #param_types), )*
             ).await.map_err(|error| error.to_framework_error(ctx))?;
 
-            if !ctx.framework.options.manual_cooldowns {
+            if !ctx.framework.options.manual_cooldowns && !ctx.command.manual_cooldowns {
                 ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());
             }
 
@@ -215,7 +215,7 @@ pub fn generate_context_menu_action(
     Ok(quote::quote! {
         <#param_type as ::poise::ContextMenuParameter<_, _>>::to_action(|ctx, value| {
             Box::pin(async move {
-                if !ctx.framework.options.manual_cooldowns {
+                if !ctx.framework.options.manual_cooldowns && !ctx.command.manual_cooldowns {
                     ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());
                 }
 

--- a/macros/src/command/slash.rs
+++ b/macros/src/command/slash.rs
@@ -185,7 +185,10 @@ pub fn generate_slash_action(inv: &Invocation) -> Result<proc_macro2::TokenStrea
                 #( (#param_names: #param_types), )*
             ).await.map_err(|error| error.to_framework_error(ctx))?;
 
-            if !ctx.framework.options.manual_cooldowns && !ctx.command.manual_cooldowns {
+            let is_framework_cooldown = !ctx.command.manual_cooldowns
+            .unwrap_or_else(|| ctx.framework.options.manual_cooldowns);
+
+            if is_framework_cooldown {
                 ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());
             }
 
@@ -215,7 +218,10 @@ pub fn generate_context_menu_action(
     Ok(quote::quote! {
         <#param_type as ::poise::ContextMenuParameter<_, _>>::to_action(|ctx, value| {
             Box::pin(async move {
-                if !ctx.framework.options.manual_cooldowns && !ctx.command.manual_cooldowns {
+                let is_framework_cooldown = !ctx.command.manual_cooldowns
+                .unwrap_or_else(|| ctx.framework.options.manual_cooldowns);
+
+                if is_framework_cooldown {
                     ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());
                 }
 

--- a/macros/src/command/slash.rs
+++ b/macros/src/command/slash.rs
@@ -186,7 +186,7 @@ pub fn generate_slash_action(inv: &Invocation) -> Result<proc_macro2::TokenStrea
             ).await.map_err(|error| error.to_framework_error(ctx))?;
 
             let is_framework_cooldown = !ctx.command.manual_cooldowns
-            .unwrap_or_else(|| ctx.framework.options.manual_cooldowns);
+                .unwrap_or_else(|| ctx.framework.options.manual_cooldowns);
 
             if is_framework_cooldown {
                 ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());
@@ -219,7 +219,7 @@ pub fn generate_context_menu_action(
         <#param_type as ::poise::ContextMenuParameter<_, _>>::to_action(|ctx, value| {
             Box::pin(async move {
                 let is_framework_cooldown = !ctx.command.manual_cooldowns
-                .unwrap_or_else(|| ctx.framework.options.manual_cooldowns);
+                    .unwrap_or_else(|| ctx.framework.options.manual_cooldowns);
 
                 if is_framework_cooldown {
                     ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -67,7 +67,7 @@ for example for command-specific help (i.e. `~help command_name`). Escape newlin
 - `reuse_response`: After the first response, post subsequent responses as edits to the initial message (prefix only)
 
 ## Cooldown
-
+- `manual_cooldowns`: Allows overriding the framework's built-in cooldowns tracking without affecting other commands.
 - `global_cooldown`: Minimum duration in seconds between invocations, globally
 - `user_cooldown`: Minimum duration in seconds between invocations, per user
 - `guild_cooldown`: Minimum duration in seconds between invocations, per guild

--- a/src/structs/command.rs
+++ b/src/structs/command.rs
@@ -62,7 +62,7 @@ pub struct Command<U, E> {
     ///
     /// Will override [`crate::FrameworkOptions::manual_cooldowns`] allowing manual cooldowns
     /// on select commands.
-    pub manual_cooldowns: bool,
+    pub manual_cooldowns: Option<bool>,
     /// Handles command cooldowns. Mainly for framework internal use
     pub cooldowns: std::sync::Mutex<crate::CooldownTracker>,
     /// Configuration for the [`crate::CooldownTracker`]

--- a/src/structs/command.rs
+++ b/src/structs/command.rs
@@ -58,6 +58,11 @@ pub struct Command<U, E> {
     /// Multiline description with detailed usage instructions. Displayed in the command specific
     /// help: `~help command_name`
     pub help_text: Option<String>,
+    /// if `true`, disables automatic cooldown handling before this commands invocation.
+    ///
+    /// Will override [`crate::FrameworkOptions::manual_cooldowns`] allowing manual cooldowns
+    /// on select commands.
+    pub manual_cooldowns: bool,
     /// Handles command cooldowns. Mainly for framework internal use
     pub cooldowns: std::sync::Mutex<crate::CooldownTracker>,
     /// Configuration for the [`crate::CooldownTracker`]


### PR DESCRIPTION
Not sure if adding fields to `Command` is breaking, it can be constructed publicly so maybe? will rebase to `next` on request.

Currently it is treated like an override, but if allowing users to have manual cooldowns on for every command but a few select ones is desired, this could be an `Option<bool>`.

I have not adjusted the examples, but in the current state there isn't really anything to add. Maybe a comment somewhere saying that it can be done for specific commands?

