### PR TITLE
Rework permission checks

### DIFF
--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -173,6 +173,10 @@ pub async fn on_error<U, E: std::fmt::Display + std::fmt::Debug>(
             ctx.send(CreateReply::default().content(response).ephemeral(true))
                 .await?;
         }
+        crate::FrameworkError::PermissionFetchFailed { ctx } => {
+            ctx.say("An error occurred when fetching permissions.")
+                .await?;
+        }
         crate::FrameworkError::NotAnOwner { ctx } => {
             let response = "Only bot owners can call this command";
             ctx.send(CreateReply::default().content(response).ephemeral(true))

--- a/src/dispatch/common.rs
+++ b/src/dispatch/common.rs
@@ -2,23 +2,45 @@
 
 use crate::serenity_prelude as serenity;
 
+/// Used in `user_permissions`, if a user is passed to that function, their permissions will be
+/// returned, in DMs the return value with be `Permissions::all()`.
+struct PermissionsInfo {
+    /// The Permissions of the user, if requested.
+    user_permissions: Option<serenity::Permissions>,
+    /// The Permissions of the bot, if requested.
+    bot_permissions: Option<serenity::Permissions>,
+}
+
 /// Retrieves user permissions in the given channel. If unknown, returns None. If in DMs, returns
 /// `Permissions::all()`.
-async fn user_permissions(
-    ctx: &serenity::Context,
-    guild_id: Option<serenity::GuildId>,
-    channel_id: serenity::ChannelId,
-    user_id: serenity::UserId,
-) -> Option<serenity::Permissions> {
-    let guild_id = match guild_id {
-        Some(x) => x,
-        None => return Some(serenity::Permissions::all()), // no permission checks in DMs
+async fn users_permissions<U, E>(
+    ctx: crate::Context<'_, U, E>,
+    user_id: Option<serenity::UserId>,
+    bot_id: Option<serenity::UserId>,
+) -> Option<PermissionsInfo> {
+    let guild_id = ctx.guild_id();
+    let channel_id = ctx.channel_id();
+    // No permission checks in DMs.
+    let Some(guild_id) = guild_id else {
+        return Some(PermissionsInfo {
+            user_permissions: Some(serenity::Permissions::all()),
+            bot_permissions: Some(serenity::Permissions::all()),
+        });
     };
 
-    let guild = guild_id.to_partial_guild(ctx).await.ok()?;
+    if let crate::Context::Application(ctx) = ctx {
+        // This should be present on all interactions within a guild. But discord can be a bit
+        // funny sometimes, so lets be safe.
+        if let Some(member) = &ctx.interaction.member {
+            return Some(PermissionsInfo {
+                user_permissions: member.permissions,
+                bot_permissions: ctx.interaction.app_permissions,
+            });
+        }
+    }
 
     // Use to_channel so that it can fallback on HTTP for threads (which aren't in cache usually)
-    let channel = match channel_id.to_channel(ctx).await {
+    let channel = match channel_id.to_channel(ctx.serenity_context()).await {
         Ok(serenity::Channel::Guild(channel)) => channel,
         Ok(_other_channel) => {
             tracing::warn!(
@@ -29,31 +51,125 @@ async fn user_permissions(
         Err(_) => return None,
     };
 
-    let member = guild.member(ctx, user_id).await.ok()?;
+    // These are done by HTTP only to prevent outdated data with no GUILD_MEMBERS intent.
+    let user_member = if let Some(user_id) = user_id {
+        Some(
+            guild_id
+                .member(ctx.serenity_context(), user_id)
+                .await
+                .ok()?,
+        )
+    } else {
+        None
+    };
 
-    Some(guild.user_permissions_in(&channel, &member))
+    let bot_member = if let Some(bot_id) = bot_id {
+        Some(guild_id.member(ctx.serenity_context(), bot_id).await.ok()?)
+    } else {
+        None
+    };
+
+    get_user_permissions(ctx, &channel, user_member.as_ref(), bot_member.as_ref()).await
 }
 
 /// Retrieves the set of permissions that are lacking, relative to the given required permission set
 ///
 /// Returns None if permissions couldn't be retrieved
-async fn missing_permissions<U, E>(
+async fn get_user_permissions<U, E>(
     ctx: crate::Context<'_, U, E>,
-    user: serenity::UserId,
-    required_permissions: serenity::Permissions,
-) -> Option<serenity::Permissions> {
-    if required_permissions.is_empty() {
-        return Some(serenity::Permissions::empty());
+    channel: &serenity::GuildChannel,
+    user: Option<&serenity::Member>,
+    bot: Option<&serenity::Member>,
+) -> Option<PermissionsInfo> {
+    #[cfg(feature = "cache")]
+    if let Some(permissions) = cached_guild(ctx, channel, user, bot) {
+        Some(permissions)
+    } else {
+        fetch_guild(ctx, channel, user, bot).await
     }
 
-    let permissions = user_permissions(
-        ctx.serenity_context(),
-        ctx.guild_id(),
-        ctx.channel_id(),
-        user,
-    )
-    .await;
-    Some(required_permissions - permissions?)
+    #[cfg(not(feature = "cache"))]
+    fetch_guild(ctx, channel, user, bot).await
+}
+
+#[cfg(feature = "cache")]
+/// Checks the cache for the guild, returning the permissions if present.
+fn cached_guild<U, E>(
+    ctx: crate::Context<'_, U, E>,
+    channel: &serenity::GuildChannel,
+    user: Option<&serenity::Member>,
+    bot: Option<&serenity::Member>,
+) -> Option<PermissionsInfo> {
+    ctx.guild().map(|guild| {
+        let user_permissions = user.map(|m| guild.user_permissions_in(channel, m));
+        let bot_permissions = bot.map(|m| guild.user_permissions_in(channel, m));
+
+        PermissionsInfo {
+            user_permissions,
+            bot_permissions,
+        }
+    })
+}
+
+/// Fetches the partial guild from http, returning the permissions if available.
+async fn fetch_guild<U, E>(
+    ctx: crate::Context<'_, U, E>,
+    channel: &serenity::GuildChannel,
+    user: Option<&serenity::Member>,
+    bot: Option<&serenity::Member>,
+) -> Option<PermissionsInfo> {
+    let partial_guild = channel.guild_id.to_partial_guild(ctx.http()).await.ok()?;
+
+    let user_permissions = user.map(|m| partial_guild.user_permissions_in(channel, m));
+    let bot_permissions = bot.map(|m| partial_guild.user_permissions_in(channel, m));
+
+    Some(PermissionsInfo {
+        user_permissions,
+        bot_permissions,
+    })
+}
+
+/// Retrieves the set of permissions that are lacking, relative to the given required permission set
+///
+/// Returns None if permissions couldn't be retrieved.
+async fn missing_permissions<U, E>(
+    ctx: crate::Context<'_, U, E>,
+    user_id: serenity::UserId,
+    user_permissions: serenity::Permissions,
+    bot_id: serenity::UserId,
+    bot_permissions: serenity::Permissions,
+) -> Option<(serenity::Permissions, serenity::Permissions)> {
+    // If both user and bot are None, return empty permissions
+    if user_permissions.is_empty() && bot_permissions.is_empty() {
+        return Some((
+            serenity::Permissions::empty(),
+            serenity::Permissions::empty(),
+        ));
+    }
+
+    let user_id = match user_permissions.is_empty() {
+        true => None,
+        false => Some(user_id),
+    };
+
+    let bot_id = match bot_permissions.is_empty() {
+        true => None,
+        false => Some(bot_id),
+    };
+
+    // Fetch permissions, returning None if an error occurred
+    let permissions = users_permissions(ctx, user_id, bot_id).await?;
+
+    let user_missing_perms = permissions
+        .user_permissions
+        .map(|permissions| user_permissions - permissions)
+        .unwrap_or_default();
+    let bot_missing_perms = permissions
+        .bot_permissions
+        .map(|permissions| bot_permissions - permissions)
+        .unwrap_or_default();
+
+    Some((user_missing_perms, bot_missing_perms))
 }
 
 /// See [`check_permissions_and_cooldown`]. Runs the check only for a single command. The caller
@@ -111,35 +227,38 @@ async fn check_permissions_and_cooldown_single<'a, U, E>(
     }
 
     // Make sure that user has required permissions
-    match missing_permissions(ctx, ctx.author().id, cmd.required_permissions).await {
-        Some(missing_permissions) if missing_permissions.is_empty() => {}
-        Some(missing_permissions) => {
+    if let Some((user_missing_permissions, bot_missing_permissions)) = missing_permissions(
+        ctx,
+        ctx.author().id,
+        cmd.required_permissions,
+        ctx.framework().bot_id(),
+        cmd.required_bot_permissions,
+    )
+    .await
+    {
+        if !user_missing_permissions.is_empty() {
             return Err(crate::FrameworkError::MissingUserPermissions {
                 ctx,
-                missing_permissions: Some(missing_permissions),
-            })
+                missing_permissions: Some(user_missing_permissions),
+            });
         }
-        // Better safe than sorry: when perms are unknown, restrict access
-        None => {
-            return Err(crate::FrameworkError::MissingUserPermissions {
-                ctx,
-                missing_permissions: None,
-            })
-        }
-    }
 
-    // Before running any pre-command checks, make sure the bot has the permissions it needs
-    match missing_permissions(ctx, ctx.framework().bot_id(), cmd.required_bot_permissions).await {
-        Some(missing_permissions) if missing_permissions.is_empty() => {}
-        Some(missing_permissions) => {
+        if !bot_missing_permissions.is_empty() {
             return Err(crate::FrameworkError::MissingBotPermissions {
                 ctx,
-                missing_permissions,
-            })
+                missing_permissions: bot_missing_permissions,
+            });
         }
-        // When in doubt, just let it run. Not getting fancy missing permissions errors is better
-        // than the command not executing at all
-        None => {}
+
+        // missing premission checks here.
+    } else {
+        // TODO: ask what I should do here because combining the checks loses the verbosity.
+        // the only previous failure point was it failing to get the guild, channel or members.
+        // Previously when a bots permissions could not be fetched it would just allow execution.
+        return Err(crate::FrameworkError::MissingUserPermissions {
+            missing_permissions: None,
+            ctx,
+        });
     }
 
     // Only continue if command checks returns true

--- a/src/dispatch/common.rs
+++ b/src/dispatch/common.rs
@@ -249,16 +249,8 @@ async fn check_permissions_and_cooldown_single<'a, U, E>(
                 missing_permissions: bot_missing_permissions,
             });
         }
-
-        // missing premission checks here.
     } else {
-        // TODO: ask what I should do here because combining the checks loses the verbosity.
-        // the only previous failure point was it failing to get the guild, channel or members.
-        // Previously when a bots permissions could not be fetched it would just allow execution.
-        return Err(crate::FrameworkError::MissingUserPermissions {
-            missing_permissions: None,
-            ctx,
-        });
+        return Err(crate::FrameworkError::PermissionFetchFailed { ctx });
     }
 
     // Only continue if command checks returns true

--- a/src/dispatch/common.rs
+++ b/src/dispatch/common.rs
@@ -23,21 +23,26 @@ async fn users_permissions<U, E>(
     // No permission checks in DMs.
     let Some(guild_id) = guild_id else {
         return Some(PermissionsInfo {
-            user_permissions: Some(serenity::Permissions::all()),
-            bot_permissions: Some(serenity::Permissions::all()),
+            user_permissions: Some(serenity::Permissions::dm_permissions()),
+            bot_permissions: Some(serenity::Permissions::dm_permissions()),
         });
     };
 
-    if let crate::Context::Application(ctx) = ctx {
-        // This should be present on all interactions within a guild. But discord can be a bit
-        // funny sometimes, so lets be safe.
-        if let Some(member) = &ctx.interaction.member {
+    let ctx = match ctx {
+        crate::Context::Application(ctx) => {
+            let user_permissions = if let Some(member) = &ctx.interaction.member {
+                member.permissions
+            } else {
+                Some(serenity::Permissions::dm_permissions())
+            };
+
             return Some(PermissionsInfo {
-                user_permissions: member.permissions,
+                user_permissions,
                 bot_permissions: ctx.interaction.app_permissions,
             });
         }
-    }
+        crate::Context::Prefix(ctx) => ctx,
+    };
 
     // Use to_channel so that it can fallback on HTTP for threads (which aren't in cache usually)
     let channel = match channel_id.to_channel(ctx.serenity_context()).await {
@@ -51,76 +56,78 @@ async fn users_permissions<U, E>(
         Err(_) => return None,
     };
 
-    // These are done by HTTP only to prevent outdated data with no GUILD_MEMBERS intent.
-    let user_member = if let Some(user_id) = user_id {
-        Some(
-            guild_id
-                .member(ctx.serenity_context(), user_id)
-                .await
-                .ok()?,
-        )
-    } else {
-        None
-    };
-
+    // If present in this function (user requested it) it'll be Some(), else None.
     let bot_member = if let Some(bot_id) = bot_id {
-        Some(guild_id.member(ctx.serenity_context(), bot_id).await.ok()?)
+        Some(guild_id.member(ctx.http(), bot_id).await.ok()?)
     } else {
         None
     };
 
-    get_user_permissions(ctx, &channel, user_member.as_ref(), bot_member.as_ref()).await
+    get_user_permissions(ctx, &channel, user_id.is_some(), bot_member.as_ref()).await
 }
 
 /// Retrieves the set of permissions that are lacking, relative to the given required permission set
 ///
 /// Returns None if permissions couldn't be retrieved
 async fn get_user_permissions<U, E>(
-    ctx: crate::Context<'_, U, E>,
+    ctx: crate::PrefixContext<'_, U, E>,
     channel: &serenity::GuildChannel,
-    user: Option<&serenity::Member>,
+    fetch_user: bool,
     bot: Option<&serenity::Member>,
 ) -> Option<PermissionsInfo> {
     #[cfg(feature = "cache")]
-    if let Some(permissions) = cached_guild(ctx, channel, user, bot) {
-        Some(permissions)
-    } else {
-        fetch_guild(ctx, channel, user, bot).await
+    if let Some(cached_perms) = check_cache_permissions(ctx, channel, fetch_user, bot) {
+        return Some(cached_perms);
     }
 
-    #[cfg(not(feature = "cache"))]
-    fetch_guild(ctx, channel, user, bot).await
+    fetch_guild(ctx, channel, fetch_user, bot).await
 }
 
+/// Retrieves the permissions from the cache, if the cache is available.
 #[cfg(feature = "cache")]
-/// Checks the cache for the guild, returning the permissions if present.
-fn cached_guild<U, E>(
-    ctx: crate::Context<'_, U, E>,
+fn check_cache_permissions<U, E>(
+    ctx: crate::PrefixContext<'_, U, E>,
     channel: &serenity::GuildChannel,
-    user: Option<&serenity::Member>,
+    fetch_user: bool,
     bot: Option<&serenity::Member>,
 ) -> Option<PermissionsInfo> {
-    ctx.guild().map(|guild| {
-        let user_permissions = user.map(|m| guild.user_permissions_in(channel, m));
-        let bot_permissions = bot.map(|m| guild.user_permissions_in(channel, m));
+    let user_permissions = if fetch_user {
+        ctx.msg.author_permissions(ctx)
+    } else {
+        None
+    };
 
-        PermissionsInfo {
+    if let Some(guild) = ctx.guild() {
+        let bot_permissions = bot.map(|bot| guild.user_permissions_in(channel, bot));
+        return Some(PermissionsInfo {
             user_permissions,
             bot_permissions,
-        }
-    })
+        });
+    }
+
+    None
 }
 
 /// Fetches the partial guild from http, returning the permissions if available.
 async fn fetch_guild<U, E>(
-    ctx: crate::Context<'_, U, E>,
+    ctx: crate::PrefixContext<'_, U, E>,
     channel: &serenity::GuildChannel,
-    user: Option<&serenity::Member>,
+    fetch_user: bool,
     bot: Option<&serenity::Member>,
 ) -> Option<PermissionsInfo> {
     let partial_guild = channel.guild_id.to_partial_guild(ctx.http()).await.ok()?;
 
-    let user_permissions = user.map(|m| partial_guild.user_permissions_in(channel, m));
+    let user_permissions = if fetch_user {
+        let partial_member = ctx
+            .msg
+            .member
+            .as_ref()
+            .expect("Member should always be present on a gateway message in a guild.");
+        Some(partial_guild.partial_member_permissions_in(channel, ctx.author().id, partial_member))
+    } else {
+        None
+    };
+
     let bot_permissions = bot.map(|m| partial_guild.user_permissions_in(channel, m));
 
     Some(PermissionsInfo {

--- a/src/dispatch/common.rs
+++ b/src/dispatch/common.rs
@@ -2,183 +2,6 @@
 
 use crate::serenity_prelude as serenity;
 
-/// Used in `user_permissions`, if a user is passed to that function, their permissions will be
-/// returned, in DMs the return value with be `Permissions::all()`.
-struct PermissionsInfo {
-    /// The Permissions of the user, if requested.
-    user_permissions: Option<serenity::Permissions>,
-    /// The Permissions of the bot, if requested.
-    bot_permissions: Option<serenity::Permissions>,
-}
-
-/// Retrieves user permissions in the given channel. If unknown, returns None. If in DMs, returns
-/// `Permissions::all()`.
-async fn users_permissions<U, E>(
-    ctx: crate::Context<'_, U, E>,
-    user_id: Option<serenity::UserId>,
-    bot_id: Option<serenity::UserId>,
-) -> Option<PermissionsInfo> {
-    let guild_id = ctx.guild_id();
-    let channel_id = ctx.channel_id();
-    // No permission checks in DMs.
-    let Some(guild_id) = guild_id else {
-        return Some(PermissionsInfo {
-            user_permissions: Some(serenity::Permissions::dm_permissions()),
-            bot_permissions: Some(serenity::Permissions::dm_permissions()),
-        });
-    };
-
-    let ctx = match ctx {
-        crate::Context::Application(ctx) => {
-            let user_permissions = if let Some(member) = &ctx.interaction.member {
-                member.permissions
-            } else {
-                Some(serenity::Permissions::dm_permissions())
-            };
-
-            return Some(PermissionsInfo {
-                user_permissions,
-                bot_permissions: ctx.interaction.app_permissions,
-            });
-        }
-        crate::Context::Prefix(ctx) => ctx,
-    };
-
-    // Use to_channel so that it can fallback on HTTP for threads (which aren't in cache usually)
-    let channel = match channel_id.to_channel(ctx.serenity_context()).await {
-        Ok(serenity::Channel::Guild(channel)) => channel,
-        Ok(_other_channel) => {
-            tracing::warn!(
-                "guild message was supposedly sent in a non-guild channel. Denying invocation"
-            );
-            return None;
-        }
-        Err(_) => return None,
-    };
-
-    // If present in this function (user requested it) it'll be Some(), else None.
-    let bot_member = if let Some(bot_id) = bot_id {
-        Some(guild_id.member(ctx.http(), bot_id).await.ok()?)
-    } else {
-        None
-    };
-
-    get_user_permissions(ctx, &channel, user_id.is_some(), bot_member.as_ref()).await
-}
-
-/// Retrieves the set of permissions that are lacking, relative to the given required permission set
-///
-/// Returns None if permissions couldn't be retrieved
-async fn get_user_permissions<U, E>(
-    ctx: crate::PrefixContext<'_, U, E>,
-    channel: &serenity::GuildChannel,
-    fetch_user: bool,
-    bot: Option<&serenity::Member>,
-) -> Option<PermissionsInfo> {
-    #[cfg(feature = "cache")]
-    if let Some(cached_perms) = check_cache_permissions(ctx, channel, fetch_user, bot) {
-        return Some(cached_perms);
-    }
-
-    fetch_guild(ctx, channel, fetch_user, bot).await
-}
-
-/// Retrieves the permissions from the cache, if the cache is available.
-#[cfg(feature = "cache")]
-fn check_cache_permissions<U, E>(
-    ctx: crate::PrefixContext<'_, U, E>,
-    channel: &serenity::GuildChannel,
-    fetch_user: bool,
-    bot: Option<&serenity::Member>,
-) -> Option<PermissionsInfo> {
-    let user_permissions = if fetch_user {
-        ctx.msg.author_permissions(ctx)
-    } else {
-        None
-    };
-
-    if let Some(guild) = ctx.guild() {
-        let bot_permissions = bot.map(|bot| guild.user_permissions_in(channel, bot));
-        return Some(PermissionsInfo {
-            user_permissions,
-            bot_permissions,
-        });
-    }
-
-    None
-}
-
-/// Fetches the partial guild from http, returning the permissions if available.
-async fn fetch_guild<U, E>(
-    ctx: crate::PrefixContext<'_, U, E>,
-    channel: &serenity::GuildChannel,
-    fetch_user: bool,
-    bot: Option<&serenity::Member>,
-) -> Option<PermissionsInfo> {
-    let partial_guild = channel.guild_id.to_partial_guild(ctx.http()).await.ok()?;
-
-    let user_permissions = if fetch_user {
-        let partial_member = ctx
-            .msg
-            .member
-            .as_ref()
-            .expect("Member should always be present on a gateway message in a guild.");
-        Some(partial_guild.partial_member_permissions_in(channel, ctx.author().id, partial_member))
-    } else {
-        None
-    };
-
-    let bot_permissions = bot.map(|m| partial_guild.user_permissions_in(channel, m));
-
-    Some(PermissionsInfo {
-        user_permissions,
-        bot_permissions,
-    })
-}
-
-/// Retrieves the set of permissions that are lacking, relative to the given required permission set
-///
-/// Returns None if permissions couldn't be retrieved.
-async fn missing_permissions<U, E>(
-    ctx: crate::Context<'_, U, E>,
-    user_id: serenity::UserId,
-    user_permissions: serenity::Permissions,
-    bot_id: serenity::UserId,
-    bot_permissions: serenity::Permissions,
-) -> Option<(serenity::Permissions, serenity::Permissions)> {
-    // If both user and bot are None, return empty permissions
-    if user_permissions.is_empty() && bot_permissions.is_empty() {
-        return Some((
-            serenity::Permissions::empty(),
-            serenity::Permissions::empty(),
-        ));
-    }
-
-    let user_id = match user_permissions.is_empty() {
-        true => None,
-        false => Some(user_id),
-    };
-
-    let bot_id = match bot_permissions.is_empty() {
-        true => None,
-        false => Some(bot_id),
-    };
-
-    // Fetch permissions, returning None if an error occurred
-    let permissions = users_permissions(ctx, user_id, bot_id).await?;
-
-    let user_missing_perms = permissions
-        .user_permissions
-        .map(|permissions| user_permissions - permissions)
-        .unwrap_or_default();
-    let bot_missing_perms = permissions
-        .bot_permissions
-        .map(|permissions| bot_permissions - permissions)
-        .unwrap_or_default();
-
-    Some((user_missing_perms, bot_missing_perms))
-}
-
 /// See [`check_permissions_and_cooldown`]. Runs the check only for a single command. The caller
 /// should call this multiple time for each parent command to achieve the check inheritance logic.
 async fn check_permissions_and_cooldown_single<'a, U, E>(
@@ -234,14 +57,13 @@ async fn check_permissions_and_cooldown_single<'a, U, E>(
     }
 
     // Make sure that user has required permissions
-    if let Some((user_missing_permissions, bot_missing_permissions)) = missing_permissions(
-        ctx,
-        ctx.author().id,
-        cmd.required_permissions,
-        ctx.framework().bot_id(),
-        cmd.required_bot_permissions,
-    )
-    .await
+    if let Some((user_missing_permissions, bot_missing_permissions)) =
+        super::permissions::calculate_missing(
+            ctx,
+            cmd.required_permissions,
+            cmd.required_bot_permissions,
+        )
+        .await
     {
         if !user_missing_permissions.is_empty() {
             return Err(crate::FrameworkError::MissingUserPermissions {

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -1,6 +1,7 @@
 //! Contains all code to dispatch incoming events onto framework commands
 
 mod common;
+mod permissions;
 mod prefix;
 mod slash;
 

--- a/src/dispatch/permissions.rs
+++ b/src/dispatch/permissions.rs
@@ -1,0 +1,82 @@
+//! Module for calculating permission checks for commands
+
+use crate::serenity_prelude as serenity;
+
+mod application;
+mod prefix;
+
+/// Simple POD type to hold the results of permission lookups.
+struct PermissionsInfo {
+    /// The Permissions of the author, if requested.
+    author_permissions: Option<serenity::Permissions>,
+    /// The Permissions of the bot, if requested.
+    bot_permissions: Option<serenity::Permissions>,
+}
+
+impl PermissionsInfo {
+    /// Returns the fake permissions info from a DM.
+    fn dm_permissions() -> Self {
+        Self {
+            author_permissions: Some(serenity::Permissions::dm_permissions()),
+            bot_permissions: Some(serenity::Permissions::dm_permissions()),
+        }
+    }
+}
+
+/// Retrieves the permissions for the context author and the bot.
+async fn get_author_and_bot_permissions<U, E>(
+    ctx: crate::Context<'_, U, E>,
+    skip_author: bool,
+    skip_bot: bool,
+) -> Option<PermissionsInfo> {
+    // No permission checks in DMs.
+    let Some(guild_id) = ctx.guild_id() else {
+        return Some(PermissionsInfo::dm_permissions());
+    };
+
+    match ctx {
+        crate::Context::Application(ctx) => {
+            Some(application::get_author_and_bot_permissions(ctx.interaction))
+        }
+        crate::Context::Prefix(ctx) => {
+            prefix::get_author_and_bot_permissions(ctx, guild_id, skip_author, skip_bot).await
+        }
+    }
+}
+
+/// Retrieves the set of permissions that are lacking, relative to the given required permission set
+///
+/// Returns None if permissions couldn't be retrieved.
+pub(super) async fn calculate_missing<U, E>(
+    ctx: crate::Context<'_, U, E>,
+    author_required_permissions: serenity::Permissions,
+    bot_required_permissions: serenity::Permissions,
+) -> Option<(serenity::Permissions, serenity::Permissions)> {
+    // If both user and bot are None, return empty permissions
+    if author_required_permissions.is_empty() && bot_required_permissions.is_empty() {
+        return Some((
+            serenity::Permissions::empty(),
+            serenity::Permissions::empty(),
+        ));
+    }
+
+    // Fetch permissions, returning None if an error occurred
+    let permissions = get_author_and_bot_permissions(
+        ctx,
+        author_required_permissions.is_empty(),
+        bot_required_permissions.is_empty(),
+    )
+    .await?;
+
+    let author_missing_perms = permissions
+        .author_permissions
+        .map(|permissions| author_required_permissions - permissions)
+        .unwrap_or_default();
+
+    let bot_missing_perms = permissions
+        .bot_permissions
+        .map(|permissions| bot_required_permissions - permissions)
+        .unwrap_or_default();
+
+    Some((author_missing_perms, bot_missing_perms))
+}

--- a/src/dispatch/permissions/application.rs
+++ b/src/dispatch/permissions/application.rs
@@ -1,0 +1,17 @@
+//! Application command permissions calculation
+use crate::serenity_prelude as serenity;
+
+use super::PermissionsInfo;
+
+/// Gets the permissions of the ctx author and the bot.
+pub(super) fn get_author_and_bot_permissions(
+    interaction: &serenity::CommandInteraction,
+) -> PermissionsInfo {
+    let expect_err = "member is Some if interaction is in guild";
+    let author_member = interaction.member.as_ref().expect(expect_err);
+
+    PermissionsInfo {
+        author_permissions: author_member.permissions,
+        bot_permissions: interaction.app_permissions,
+    }
+}

--- a/src/dispatch/permissions/prefix/cache.rs
+++ b/src/dispatch/permissions/prefix/cache.rs
@@ -1,0 +1,62 @@
+//! The cache variant of prefix permissions calculation
+
+use crate::{serenity_prelude as serenity, PrefixContext};
+
+use crate::dispatch::permissions::PermissionsInfo;
+
+/// Gets the permissions of the ctx author and the bot.
+pub(in crate::dispatch::permissions) async fn get_author_and_bot_permissions<U, E>(
+    ctx: PrefixContext<'_, U, E>,
+    guild_id: serenity::GuildId,
+    skip_author: bool,
+    skip_bot: bool,
+) -> Option<PermissionsInfo> {
+    // Should only fail if the guild is not cached, which is fair to bail on.
+    let guild = ctx.cache().guild(guild_id)?;
+
+    let author_permissions = if skip_author {
+        None
+    } else {
+        let err_msg = "should only fail if the guild is not cached";
+        Some(ctx.msg.author_permissions(ctx.cache()).expect(err_msg))
+    };
+
+    let bot_permissions = if skip_bot {
+        None
+    } else {
+        let channel_id = ctx.channel_id();
+        let bot_user_id = ctx.framework.bot_id();
+        Some(get_bot_permissions(&guild, channel_id, bot_user_id)?)
+    };
+
+    Some(PermissionsInfo {
+        author_permissions,
+        bot_permissions,
+    })
+}
+
+/// Gets the permissions for the bot.
+fn get_bot_permissions(
+    guild: &serenity::Guild,
+    channel_id: serenity::ChannelId,
+    bot_id: serenity::UserId,
+) -> Option<serenity::Permissions> {
+    // Should never fail, as the bot member is always cached
+    let bot_member = guild.members.get(&bot_id)?;
+
+    if let Some(channel) = guild.channels.get(&channel_id) {
+        Some(guild.user_permissions_in(channel, bot_member))
+    } else if let Some(thread) = guild.threads.iter().find(|th| th.id == channel_id) {
+        let err = "parent id should always be Some for thread";
+        let parent_channel_id = thread.parent_id.expect(err);
+
+        let parent_channel = guild.channels.get(&parent_channel_id)?;
+        Some(guild.user_permissions_in(parent_channel, bot_member))
+    } else {
+        // The message was either:
+        // - Sent in a guild with broken caching
+        // - Not set in a channel or thread?
+        tracing::warn!("Could not find channel/thread ({channel_id}) for permissions check in cache for guild: {}", guild.id);
+        None
+    }
+}

--- a/src/dispatch/permissions/prefix/http.rs
+++ b/src/dispatch/permissions/prefix/http.rs
@@ -1,0 +1,40 @@
+//! The cache variant of prefix permissions calculation
+
+use crate::{serenity_prelude as serenity, PrefixContext};
+
+use crate::dispatch::permissions::PermissionsInfo;
+
+/// Gets the permissions of the ctx author and the bot.
+pub(in crate::dispatch::permissions) async fn get_author_and_bot_permissions<U, E>(
+    ctx: PrefixContext<'_, U, E>,
+    guild_id: serenity::GuildId,
+    skip_author: bool,
+    skip_bot: bool,
+) -> Option<PermissionsInfo> {
+    let http = ctx.http();
+    let guild = guild_id.to_partial_guild(http).await.ok()?;
+    let guild_channel = {
+        let channel = ctx.http().get_channel(ctx.channel_id()).await.ok()?;
+        channel.guild().expect("channel should be a guild channel")
+    };
+
+    let bot_permissions = if skip_bot {
+        None
+    } else {
+        let bot_member = guild.id.member(http, ctx.framework.bot_id).await.ok()?;
+        Some(guild.user_permissions_in(&guild_channel, &bot_member))
+    };
+
+    let author_permissions = if skip_author {
+        None
+    } else {
+        let err = "should always be Some in MessageCreateEvent";
+        let author_member = ctx.msg.member.as_ref().expect(err);
+        Some(guild.partial_member_permissions_in(&guild_channel, ctx.author().id, author_member))
+    };
+
+    Some(PermissionsInfo {
+        author_permissions,
+        bot_permissions,
+    })
+}

--- a/src/dispatch/permissions/prefix/mod.rs
+++ b/src/dispatch/permissions/prefix/mod.rs
@@ -1,0 +1,12 @@
+//! Prefix command permissions calculation
+
+#[cfg(feature = "cache")]
+mod cache;
+#[cfg(not(feature = "cache"))]
+mod http;
+
+#[cfg(feature = "cache")]
+pub(super) use cache::get_author_and_bot_permissions;
+
+#[cfg(not(feature = "cache"))]
+pub(super) use http::get_author_and_bot_permissions;

--- a/src/structs/framework_error.rs
+++ b/src/structs/framework_error.rs
@@ -114,6 +114,11 @@ pub enum FrameworkError<'a, U, E> {
         /// General context
         ctx: crate::Context<'a, U, E>,
     },
+    #[non_exhaustive]
+    PermissionFetchFailed {
+        /// General context
+        ctx: crate::Context<'a, U, E>,
+    },
     /// A non-owner tried to invoke an owners-only command
     #[non_exhaustive]
     NotAnOwner {
@@ -218,6 +223,7 @@ impl<'a, U, E> FrameworkError<'a, U, E> {
             Self::CooldownHit { ctx, .. } => ctx.serenity_context(),
             Self::MissingBotPermissions { ctx, .. } => ctx.serenity_context(),
             Self::MissingUserPermissions { ctx, .. } => ctx.serenity_context(),
+            Self::PermissionFetchFailed { ctx } => ctx.serenity_context(),
             Self::NotAnOwner { ctx, .. } => ctx.serenity_context(),
             Self::GuildOnly { ctx, .. } => ctx.serenity_context(),
             Self::DmOnly { ctx, .. } => ctx.serenity_context(),
@@ -242,6 +248,7 @@ impl<'a, U, E> FrameworkError<'a, U, E> {
             Self::CooldownHit { ctx, .. } => ctx,
             Self::MissingBotPermissions { ctx, .. } => ctx,
             Self::MissingUserPermissions { ctx, .. } => ctx,
+            Self::PermissionFetchFailed { ctx } => ctx,
             Self::NotAnOwner { ctx, .. } => ctx,
             Self::GuildOnly { ctx, .. } => ctx,
             Self::DmOnly { ctx, .. } => ctx,
@@ -367,6 +374,11 @@ impl<U, E: std::fmt::Display> std::fmt::Display for FrameworkError<'_, U, E> {
                 missing_permissions,
                 full_command_name!(ctx),
             ),
+            Self::PermissionFetchFailed { ctx } => write!(
+                f,
+                "An error occurred when trying to fetch permissions for `{}`",
+                full_command_name!(ctx)
+            ),
             Self::NotAnOwner { ctx } => write!(
                 f,
                 "owner-only command `{}` cannot be run by non-owners",
@@ -436,6 +448,7 @@ impl<'a, U: std::fmt::Debug, E: std::error::Error + 'static> std::error::Error
             Self::CooldownHit { .. } => None,
             Self::MissingBotPermissions { .. } => None,
             Self::MissingUserPermissions { .. } => None,
+            Self::PermissionFetchFailed { .. } => None,
             Self::NotAnOwner { .. } => None,
             Self::GuildOnly { .. } => None,
             Self::DmOnly { .. } => None,

--- a/src/structs/framework_error.rs
+++ b/src/structs/framework_error.rs
@@ -114,6 +114,8 @@ pub enum FrameworkError<'a, U, E> {
         /// General context
         ctx: crate::Context<'a, U, E>,
     },
+    /// The command was invoked, but an error occurred while fetching the necessary information to
+    /// verify permissions.
     #[non_exhaustive]
     PermissionFetchFailed {
         /// General context


### PR DESCRIPTION
This shouldn't be breaking in the traditional sense, but does theoretically change behaviour in one case.

Previously, when the bots permissions could not be checked, it let the command run, now it fires a UserPermissionsError, there isn't really a nice way of checking where the error came from because the only place this can happen is in http requests.

The guild, channel or member itself could be the failure point, the only place we can now tell is directly on which member failed to fetch and return the "right" error from there.

I've placed a comment in the code about it, I just want to check if this is okay or if I should attempt to get the right error even though the only place it can come from is http.


I can pull the member from the cache too if that is desirable, but developers without `GUILD_MEMBERS` may suffer from this change. I believe checking for this is doable by directly accessing `Http`, but this is currently out of scope and can be handled later if that is desirable.

In `serenity-next` the channel http request has already been removed and I'd rather not mess around doing that bit manually and falling back to http if it isn't cached.

CURRENTLY UNTESTED.