### PR TITLE
Fix default_member_permissions not being checked for context_menu_command

### DIFF
--- a/src/structs/command.rs
+++ b/src/structs/command.rs
@@ -249,8 +249,7 @@ impl<U, E> Command<U, E> {
         });
 
         // This is_empty check is needed because Discord special cases empty
-        // default_member_permissions to mean "everyone". Without this, all Poise context menu commands
-        // would be available to all users regardless of default_member_permissions setting.
+        // default_member_permissions to mean "admin-only"
         if !self.default_member_permissions.is_empty() {
             builder = builder.default_member_permissions(self.default_member_permissions);
         }

--- a/src/structs/command.rs
+++ b/src/structs/command.rs
@@ -248,6 +248,13 @@ impl<U, E> Command<U, E> {
             crate::ContextMenuCommandAction::__NonExhaustive => unreachable!(),
         });
 
+        // This is_empty check is needed because Discord special cases empty
+        // default_member_permissions to mean "everyone". Without this, all Poise context menu commands
+        // would be available to all users regardless of default_member_permissions setting.
+        if !self.default_member_permissions.is_empty() {
+            builder = builder.default_member_permissions(self.default_member_permissions);
+        }
+
         if self.guild_only {
             builder = builder.contexts(vec![serenity::InteractionContext::Guild]);
         } else if self.dm_only {


### PR DESCRIPTION
<!-- base the PR on the current branch, if it has no breaking changes, and on the next branch, if it does -->

This PR fixes default_member_permissions not being checked for context menu commands.

Commands with `context_menu_command` currently do not use the command macro's configured default_member_permissions. If default_member_permissions is not set in the command's builder, the context menu command will default to allowing all users.

This is a security footgun, as it's very easy to make a command intended for privileged users and overlook the fact that the permissions are only enforced on the slash command variant and not the context menu command. My bot exclusively uses default_member_permissions for command permission checks and I almost missed this bug, which would have given all users access to commands intended only for server moderators.
