### PR TITLE
create_application_commands can now take any IntoIterator: not just &[]

### DIFF
--- a/src/builtins/register.rs
+++ b/src/builtins/register.rs
@@ -16,8 +16,8 @@ use crate::serenity_prelude as serenity;
 /// serenity::Command::set_global_commands(ctx, create_commands).await?;
 /// # Ok(()) }
 /// ```
-pub fn create_application_commands<U, E>(
-    commands: &[crate::Command<U, E>],
+pub fn create_application_commands<'a, U:'a , E: 'a>(
+    commands: impl IntoIterator<Item=&'a crate::Command<U, E>>,
 ) -> Vec<serenity::CreateCommand> {
     /// We decided to extract context menu commands recursively, despite the subcommand hierarchy
     /// not being preserved. Because it's more confusing to just silently discard context menu
@@ -35,7 +35,7 @@ pub fn create_application_commands<U, E>(
         }
     }
 
-    let mut commands_builder = Vec::with_capacity(commands.len());
+    let mut commands_builder = Vec::new();
     for command in commands {
         if let Some(slash_command) = command.create_as_slash_command() {
             commands_builder.push(slash_command);

--- a/src/builtins/register.rs
+++ b/src/builtins/register.rs
@@ -16,8 +16,8 @@ use crate::serenity_prelude as serenity;
 /// serenity::Command::set_global_commands(ctx, create_commands).await?;
 /// # Ok(()) }
 /// ```
-pub fn create_application_commands<'a, U:'a , E: 'a>(
-    commands: impl IntoIterator<Item=&'a crate::Command<U, E>>,
+pub fn create_application_commands<'a, U: 'a, E: 'a>(
+    commands: impl IntoIterator<Item = &'a crate::Command<U, E>>,
 ) -> Vec<serenity::CreateCommand> {
     /// We decided to extract context menu commands recursively, despite the subcommand hierarchy
     /// not being preserved. Because it's more confusing to just silently discard context menu
@@ -51,7 +51,7 @@ pub fn create_application_commands<'a, U:'a , E: 'a>(
 /// [`serenity::Command::set_global_commands`].
 pub async fn register_globally<'a, U: 'a, E: 'a>(
     http: impl AsRef<serenity::Http>,
-    commands: impl IntoIterator<Item=&'a crate::Command<U, E>>,
+    commands: impl IntoIterator<Item = &'a crate::Command<U, E>>,
 ) -> Result<(), serenity::Error> {
     let builder = create_application_commands(commands);
     serenity::Command::set_global_commands(http, builder).await?;
@@ -64,7 +64,7 @@ pub async fn register_globally<'a, U: 'a, E: 'a>(
 /// [`serenity::GuildId::set_commands`].
 pub async fn register_in_guild<'a, U: 'a, E: 'a>(
     http: impl AsRef<serenity::Http>,
-    commands: impl IntoIterator<Item=&'a crate::Command<U, E>>,
+    commands: impl IntoIterator<Item = &'a crate::Command<U, E>>,
     guild_id: serenity::GuildId,
 ) -> Result<(), serenity::Error> {
     let builder = create_application_commands(commands);

--- a/src/builtins/register.rs
+++ b/src/builtins/register.rs
@@ -49,9 +49,9 @@ pub fn create_application_commands<'a, U:'a , E: 'a>(
 ///
 /// Thin wrapper around [`create_application_commands`] that funnels the returned builder into
 /// [`serenity::Command::set_global_commands`].
-pub async fn register_globally<U, E>(
+pub async fn register_globally<'a, U: 'a, E: 'a>(
     http: impl AsRef<serenity::Http>,
-    commands: &[crate::Command<U, E>],
+    commands: impl IntoIterator<Item=&'a crate::Command<U, E>>,
 ) -> Result<(), serenity::Error> {
     let builder = create_application_commands(commands);
     serenity::Command::set_global_commands(http, builder).await?;
@@ -62,9 +62,9 @@ pub async fn register_globally<U, E>(
 ///
 /// Thin wrapper around [`create_application_commands`] that funnels the returned builder into
 /// [`serenity::GuildId::set_commands`].
-pub async fn register_in_guild<U, E>(
+pub async fn register_in_guild<'a, U: 'a, E: 'a>(
     http: impl AsRef<serenity::Http>,
-    commands: &[crate::Command<U, E>],
+    commands: impl IntoIterator<Item=&'a crate::Command<U, E>>,
     guild_id: serenity::GuildId,
 ) -> Result<(), serenity::Error> {
     let builder = create_application_commands(commands);

--- a/src/builtins/register.rs
+++ b/src/builtins/register.rs
@@ -35,8 +35,9 @@ pub fn create_application_commands<'a, U: 'a, E: 'a>(
         }
     }
 
-    let mut commands_builder = Vec::new();
-    for command in commands {
+    let command_iter = commands.into_iter();
+    let mut commands_builder = Vec::with_capacity(command_iter.size_hint().0);
+    for command in command_iter {
         if let Some(slash_command) = command.create_as_slash_command() {
             commands_builder.push(slash_command);
         }


### PR DESCRIPTION
<!-- base the PR on the current branch, if it has no breaking changes, and on the next branch, if it does -->

This is a small change: currently `poise::builtins::create_application_commands` takes a `&[crate::Command<U, E>]`. This PR changes it to take an `IntoIterator<Item=&crate::Command<U, E>>`. This doesn't really change much, except it makes the API slightly easier to work with if API users don't simply have a `Vec<Command<U, E>` lying around: for example if you're dynamically computing which commands should be set on a guild-by-guild basis.