### PR TITLE
Allow edited messages and interactions to be sent without removing existing embeds

### DIFF
--- a/src/builtins/pretty_help.rs
+++ b/src/builtins/pretty_help.rs
@@ -36,7 +36,7 @@ impl Default for PrettyHelpConfiguration<'_> {
     }
 }
 
-/// A help command that works similarly to `builtin::help` butt outputs text in an embed.
+/// A help command that works similarly to `builtin::help` but outputs text in an embed.
 ///
 pub async fn pretty_help<U, E>(
     ctx: crate::Context<'_, U, E>,

--- a/src/reply/builder.rs
+++ b/src/reply/builder.rs
@@ -32,7 +32,7 @@ impl CreateReply {
     /// Existing embeds on this are kept.
     /// When editing a message, this will overwrite previously sent embeds.
     pub fn embed(mut self, embed: serenity::CreateEmbed) -> Self {
-        self.embeds.get_or_insert_with(|| Default::default()).push(embed);
+        self.embeds.get_or_insert_with(Vec::new).push(embed);
         self
     }
 

--- a/src/reply/builder.rs
+++ b/src/reply/builder.rs
@@ -114,11 +114,11 @@ impl CreateReply {
         if let Some(components) = components {
             builder = builder.components(components);
         }
-        if let Some(ephemeral) = ephemeral {
-            builder = builder.ephemeral(ephemeral);
-        }
         if let Some(embeds) = embeds {
             builder = builder.embeds(embeds);
+        }
+        if let Some(ephemeral) = ephemeral {
+            builder = builder.ephemeral(ephemeral);
         }
 
         builder.add_files(attachments)
@@ -142,11 +142,11 @@ impl CreateReply {
         if let Some(content) = content {
             builder = builder.content(content);
         }
-        if let Some(embeds) = embeds {
-            builder = builder.embeds(embeds);
-        }
         if let Some(components) = components {
             builder = builder.components(components)
+        }
+        if let Some(embeds) = embeds {
+            builder = builder.embeds(embeds);
         }
         if let Some(allowed_mentions) = allowed_mentions {
             builder = builder.allowed_mentions(allowed_mentions);
@@ -179,11 +179,11 @@ impl CreateReply {
         if let Some(components) = components {
             builder = builder.components(components);
         }
-        if let Some(allowed_mentions) = allowed_mentions {
-            builder = builder.allowed_mentions(allowed_mentions);
-        }
         if let Some(embeds) = embeds {
             builder = builder.embeds(embeds);
+        }
+        if let Some(allowed_mentions) = allowed_mentions {
+            builder = builder.allowed_mentions(allowed_mentions);
         }
 
         builder

--- a/src/reply/builder.rs
+++ b/src/reply/builder.rs
@@ -7,7 +7,7 @@ use crate::serenity_prelude as serenity;
 #[allow(clippy::missing_docs_in_private_items)] // docs on setters
 pub struct CreateReply {
     content: Option<String>,
-    embeds: Vec<serenity::CreateEmbed>,
+    embeds: Option<Vec<serenity::CreateEmbed>>,
     attachments: Vec<serenity::CreateAttachment>,
     pub(crate) ephemeral: Option<bool>,
     components: Option<Vec<serenity::CreateActionRow>>,
@@ -29,9 +29,18 @@ impl CreateReply {
 
     /// Adds an embed to the message.
     ///
-    /// Existing embeds are kept.
+    /// Existing embeds on this are kept.
+    /// When editing a message, this will overwrite previously sent embeds.
     pub fn embed(mut self, embed: serenity::CreateEmbed) -> Self {
-        self.embeds.push(embed);
+        self.embeds.get_or_insert_with(|| Default::default()).push(embed);
+        self
+    }
+
+    /// Set embeds for the message.
+    ///
+    /// Any previously set embeds will be overwritten.
+    pub fn embeds(mut self, embeds: Vec<serenity::CreateEmbed>) -> Self {
+        self.embeds = Some(embeds);
         self
     }
 
@@ -108,8 +117,11 @@ impl CreateReply {
         if let Some(ephemeral) = ephemeral {
             builder = builder.ephemeral(ephemeral);
         }
+        if let Some(embeds) = embeds {
+            builder = builder.embeds(embeds);
+        }
 
-        builder.add_files(attachments).embeds(embeds)
+        builder.add_files(attachments)
     }
 
     /// Serialize this response builder to a [`serenity::CreateInteractionResponseFollowup`]
@@ -130,7 +142,9 @@ impl CreateReply {
         if let Some(content) = content {
             builder = builder.content(content);
         }
-        builder = builder.embeds(embeds);
+        if let Some(embeds) = embeds {
+            builder = builder.embeds(embeds);
+        }
         if let Some(components) = components {
             builder = builder.components(components)
         }
@@ -168,8 +182,11 @@ impl CreateReply {
         if let Some(allowed_mentions) = allowed_mentions {
             builder = builder.allowed_mentions(allowed_mentions);
         }
+        if let Some(embeds) = embeds {
+            builder = builder.embeds(embeds);
+        }
 
-        builder.embeds(embeds)
+        builder
     }
 
     /// Serialize this response builder to a [`serenity::EditMessage`]
@@ -198,8 +215,11 @@ impl CreateReply {
         if let Some(components) = components {
             builder = builder.components(components);
         }
+        if let Some(embeds) = embeds {
+            builder = builder.embeds(embeds);
+        }
 
-        builder.embeds(embeds).attachments(attachments_builder)
+        builder.attachments(attachments_builder)
     }
 
     /// Serialize this response builder to a [`serenity::CreateMessage`]
@@ -227,6 +247,9 @@ impl CreateReply {
         if let Some(components) = components {
             builder = builder.components(components);
         }
+        if let Some(embeds) = embeds {
+            builder = builder.embeds(embeds)
+        }
         if reply {
             builder = builder.reference_message(invocation_message);
         }
@@ -235,6 +258,6 @@ impl CreateReply {
             builder = builder.add_file(attachment);
         }
 
-        builder.embeds(embeds)
+        builder
     }
 }

--- a/src/slash_argument/slash_macro.rs
+++ b/src/slash_argument/slash_macro.rs
@@ -21,7 +21,7 @@ pub enum SlashArgError {
     /// A string parameter was found, but it could not be parsed into the target type.
     #[non_exhaustive]
     Parse {
-        /// Error that occured while parsing the string into the target type
+        /// Error that occurred while parsing the string into the target type
         error: Box<dyn std::error::Error + Send + Sync>,
         /// Original input string
         input: String,
@@ -32,7 +32,7 @@ pub enum SlashArgError {
         /// Human readable description of the error
         &'static str,
     ),
-    /// HTTP error occured while retrieving the model type from Discord
+    /// HTTP error occurred while retrieving the model type from Discord
     Http(serenity::Error),
     #[doc(hidden)]
     __NonExhaustive,
@@ -91,7 +91,7 @@ impl std::fmt::Display for SlashArgError {
             Self::Http(error) => {
                 write!(
                     f,
-                    "Error occured while retrieving data from Discord: {error}",
+                    "Error occurred while retrieving data from Discord: {error}",
                 )
             }
             Self::__NonExhaustive => unreachable!(),

--- a/src/structs/framework_error.rs
+++ b/src/structs/framework_error.rs
@@ -34,7 +34,7 @@ pub enum FrameworkError<'a, U, E> {
         #[derivative(Debug = "ignore")]
         framework: crate::FrameworkContext<'a, U, E>,
     },
-    /// Error occured during command execution
+    /// Error occurred during command execution
     #[non_exhaustive]
     Command {
         /// Error which was thrown in the command code
@@ -47,7 +47,7 @@ pub enum FrameworkError<'a, U, E> {
         /// General context
         ctx: crate::Context<'a, U, E>,
     },
-    /// Panic occured at any phase of command execution after constructing the `crate::Context`.
+    /// Panic occurred at any phase of command execution after constructing the `crate::Context`.
     ///
     /// This feature is intended as a last-resort safeguard to gracefully print an error message to
     /// the user on a panic. Panics should only be thrown for bugs in the code, don't use this for


### PR DESCRIPTION
Allows replies to be sent with embeds nulled out in the API, which prevents removing existing embeds under the context of editing an existing message response, both for interactions and standard messages.

This changes existing behavior - now, when not setting any embeds, existing embeds are kept. To clear them, you would call `reply.embeds(vec![])`

Pairs with https://github.com/serenity-rs/serenity/pull/2968 - this change can be made without it, but together they fix followup messages too. They can be merged separately, though the documentation on the `embed()` method is considered incorrect until this is merged on Serenity's side.

Fixes #300 

<!-- base the PR on the current branch, if it has no breaking changes, and on the next branch, if it does -->
