### PR TITLE
Perform inline choice conversion to string in macro

### DIFF
--- a/examples/feature_showcase/choice_parameter.rs
+++ b/examples/feature_showcase/choice_parameter.rs
@@ -27,7 +27,7 @@ pub async fn choice(
 //
 // Limitations: due to macro limitations (partially self-imposed, partially external), poise
 // currently does not support Options parameters, and only supports parameter types that can be
-// constructed from a literal (https://doc.rust-lang.org/reference/expressions/literal-expr.html).
+// constructed from a literal which can be converted to a string at compile time.
 
 #[poise::command(slash_command)]
 pub async fn inline_choice(


### PR DESCRIPTION
<!-- base the PR on the current branch, if it has no breaking changes, and on the next branch, if it does -->
This is a slight addition to the limitations that inline choices already faced, but is a step towards constructing `Command` at compile time which #318 couldn't do.