### PR TITLE
Add poll support

### DIFF
--- a/src/reply/builder.rs
+++ b/src/reply/builder.rs
@@ -180,7 +180,8 @@ impl CreateReply {
             components,
             ephemeral: _, // can't edit ephemerality in retrospect
             allowed_mentions,
-            poll,
+            // cannot edit polls.
+            poll: _,
             reply: _,
             __non_exhaustive: (),
         } = self;
@@ -197,9 +198,6 @@ impl CreateReply {
         for attachment in attachments {
             builder = builder.new_attachment(attachment);
         }
-        if let Some(poll) = poll {
-            builder = builder.poll(poll);
-        }
 
         builder.embeds(embeds)
     }
@@ -213,7 +211,8 @@ impl CreateReply {
             components,
             ephemeral: _, // not supported in prefix
             allowed_mentions,
-            poll,
+            // cannot edit polls.
+            poll: _,
             reply: _, // can't edit reference message afterwards
             __non_exhaustive: (),
         } = self;
@@ -231,9 +230,6 @@ impl CreateReply {
         }
         if let Some(components) = components {
             builder = builder.components(components);
-        }
-        if let Some(poll) = poll {
-            builder = builder.poll(poll);
         }
 
         builder.embeds(embeds).attachments(attachments_builder)

--- a/src/reply/builder.rs
+++ b/src/reply/builder.rs
@@ -17,6 +17,8 @@ pub struct CreateReply {
     pub components: Option<Vec<serenity::CreateActionRow>>,
     /// The allowed mentions for the message.
     pub allowed_mentions: Option<serenity::CreateAllowedMentions>,
+    /// Message poll, if present.
+    pub poll: Option<serenity::CreatePoll<serenity::builder::create_poll::Ready>>,
     /// Whether this message is an inline reply.
     pub reply: bool,
     #[doc(hidden)]
@@ -68,6 +70,17 @@ impl CreateReply {
         self
     }
 
+    /// Adds a poll to the message. Only one poll can be added per message.
+    ///
+    /// See [`serenity::CreatePoll`] for more information on creating and configuring a poll.
+    pub fn poll(
+        mut self,
+        poll: serenity::CreatePoll<serenity::builder::create_poll::Ready>,
+    ) -> Self {
+        self.poll = Some(poll);
+        self
+    }
+
     /// Makes this message an inline reply to another message like [`serenity::Message::reply`]
     /// (prefix-only, because slash commands are always inline replies anyways).
     ///
@@ -94,6 +107,7 @@ impl CreateReply {
             components,
             ephemeral,
             allowed_mentions,
+            poll,
             reply: _, // can't reply to a message in interactions
             __non_exhaustive: (),
         } = self;
@@ -109,6 +123,9 @@ impl CreateReply {
         }
         if let Some(ephemeral) = ephemeral {
             builder = builder.ephemeral(ephemeral);
+        }
+        if let Some(poll) = poll {
+            builder = builder.poll(poll);
         }
 
         builder.add_files(attachments).embeds(embeds)
@@ -126,6 +143,7 @@ impl CreateReply {
             components,
             ephemeral,
             allowed_mentions,
+            poll,
             reply: _,
             __non_exhaustive: (),
         } = self;
@@ -143,6 +161,9 @@ impl CreateReply {
         if let Some(ephemeral) = ephemeral {
             builder = builder.ephemeral(ephemeral);
         }
+        if let Some(poll) = poll {
+            builder = builder.poll(poll);
+        }
 
         builder.add_files(attachments)
     }
@@ -159,6 +180,7 @@ impl CreateReply {
             components,
             ephemeral: _, // can't edit ephemerality in retrospect
             allowed_mentions,
+            poll,
             reply: _,
             __non_exhaustive: (),
         } = self;
@@ -175,6 +197,9 @@ impl CreateReply {
         for attachment in attachments {
             builder = builder.new_attachment(attachment);
         }
+        if let Some(poll) = poll {
+            builder = builder.poll(poll);
+        }
 
         builder.embeds(embeds)
     }
@@ -188,6 +213,7 @@ impl CreateReply {
             components,
             ephemeral: _, // not supported in prefix
             allowed_mentions,
+            poll,
             reply: _, // can't edit reference message afterwards
             __non_exhaustive: (),
         } = self;
@@ -206,6 +232,9 @@ impl CreateReply {
         if let Some(components) = components {
             builder = builder.components(components);
         }
+        if let Some(poll) = poll {
+            builder = builder.poll(poll);
+        }
 
         builder.embeds(embeds).attachments(attachments_builder)
     }
@@ -222,6 +251,7 @@ impl CreateReply {
             components,
             ephemeral: _, // not supported in prefix
             allowed_mentions,
+            poll,
             reply,
             __non_exhaustive: (),
         } = self;
@@ -238,6 +268,9 @@ impl CreateReply {
         }
         if reply {
             builder = builder.reference_message(invocation_message);
+        }
+        if let Some(poll) = poll {
+            builder = builder.poll(poll);
         }
 
         for attachment in attachments {


### PR DESCRIPTION
This adds support for polls into poise. Due to these branches relying on crates.io releases and not git builds, this will not compile until the next release of serenity. Because of that this is marked as draft.

(provided I got my patches right) you should be able to use this *now* by doing this once serenity-rs/serenity#3013 is merged (or you can just point at that branch on my fork instead)

```toml
# you can change these to my forks if the PRs aren't merged.
poise = { git = "https://github.com/serenity-rs/poise", branch = "current"}
```