### PR TITLE
Fix command macro not working under #![no_implicit_prelude]

### DIFF
--- a/macros/src/choice_parameter.rs
+++ b/macros/src/choice_parameter.rs
@@ -66,9 +66,9 @@ pub fn choice_parameter(input: syn::DeriveInput) -> Result<TokenStream, darling:
     let enum_ident = &input.ident;
     let indices = 0..variant_idents.len();
     Ok(quote::quote! {
-        impl poise::ChoiceParameter for #enum_ident {
-            fn list() -> Vec<poise::CommandParameterChoice> {
-                vec![ #( poise::CommandParameterChoice {
+        impl ::poise::ChoiceParameter for #enum_ident {
+            fn list() -> Vec<::poise::CommandParameterChoice> {
+                vec![ #( ::poise::CommandParameterChoice {
                     __non_exhaustive: (),
                     name: #names.to_string(),
                     localizations: std::collections::HashMap::from([

--- a/macros/src/command/mod.rs
+++ b/macros/src/command/mod.rs
@@ -214,9 +214,9 @@ pub fn command(
         match perms {
             Some(perms) => {
                 let perms = perms.iter();
-                syn::parse_quote! { #(poise::serenity_prelude::Permissions::#perms)|* }
+                syn::parse_quote! { #(::poise::serenity_prelude::Permissions::#perms)|* }
             }
-            None => syn::parse_quote! { poise::serenity_prelude::Permissions::empty() },
+            None => syn::parse_quote! { ::poise::serenity_prelude::Permissions::empty() },
         }
     }
     let default_member_permissions = permissions_to_tokens(&args.default_member_permissions);
@@ -225,16 +225,16 @@ pub fn command(
 
     let install_context = if let Some(contexts) = &args.install_context {
         let contexts = contexts.iter();
-        syn::parse_quote! { Some(vec![ #(poise::serenity_prelude::InstallationContext::#contexts),* ]) }
+        syn::parse_quote! { ::core::option::Option::Some(vec![ #(::poise::serenity_prelude::InstallationContext::#contexts),* ]) }
     } else {
-        syn::parse_quote! { None }
+        syn::parse_quote! { ::core::option::Option::None }
     };
 
     let interaction_context = if let Some(contexts) = &args.interaction_context {
         let contexts = contexts.iter();
-        syn::parse_quote! { Some(vec![ #(poise::serenity_prelude::InteractionContext::#contexts),* ]) }
+        syn::parse_quote! { ::core::option::Option::Some(vec![ #(::poise::serenity_prelude::InteractionContext::#contexts),* ]) }
     } else {
-        syn::parse_quote! { None }
+        syn::parse_quote! { ::core::option::Option::None }
     };
 
     let inv = Invocation {
@@ -267,16 +267,16 @@ fn generate_command(mut inv: Invocation) -> Result<proc_macro2::TokenStream, dar
         syn::fold::fold_type(&mut crate::util::AllLifetimesToStatic, ctx_type.clone());
 
     let prefix_action = wrap_option(match inv.args.prefix_command {
-        true => Some(prefix::generate_prefix_action(&inv)?),
-        false => None,
+        true => ::core::option::Option::Some(prefix::generate_prefix_action(&inv)?),
+        false => ::core::option::Option::None,
     });
     let slash_action = wrap_option(match inv.args.slash_command {
-        true => Some(slash::generate_slash_action(&inv)?),
-        false => None,
+        true => ::core::option::Option::Some(slash::generate_slash_action(&inv)?),
+        false => ::core::option::Option::None,
     });
     let context_menu_action = wrap_option(match &inv.args.context_menu_command {
-        Some(_) => Some(slash::generate_context_menu_action(&inv)?),
-        None => None,
+        Some(_) => ::core::option::Option::Some(slash::generate_context_menu_action(&inv)?),
+        None => ::core::option::Option::None,
     });
 
     let function_name = inv
@@ -319,18 +319,22 @@ fn generate_command(mut inv: Invocation) -> Result<proc_macro2::TokenStream, dar
     let interaction_context = &inv.interaction_context;
 
     let help_text = match &inv.args.help_text_fn {
-        Some(help_text_fn) => quote::quote! { Some(#help_text_fn()) },
+        Some(help_text_fn) => quote::quote! { ::core::option::Option::Some(#help_text_fn()) },
         None => match &inv.help_text {
-            Some(extracted_explanation) => quote::quote! { Some(#extracted_explanation.into()) },
-            None => quote::quote! { None },
+            Some(extracted_explanation) => {
+                quote::quote! { ::core::option::Option::Some(#extracted_explanation.into()) }
+            }
+            None => quote::quote! { ::core::option::Option::None },
         },
     };
 
     let checks = &inv.args.check;
     // Box::pin the callback in order to store it in a struct
     let on_error = match &inv.args.on_error {
-        Some(on_error) => quote::quote! { Some(|err| Box::pin(#on_error(err))) },
-        None => quote::quote! { None },
+        Some(on_error) => {
+            quote::quote! { ::core::option::Option::Some(|err| ::std::boxed::Box::pin(#on_error(err))) }
+        }
+        None => quote::quote! { ::core::option::Option::None },
     };
 
     let invoke_on_edit = inv.args.invoke_on_edit || inv.args.track_edits;
@@ -343,8 +347,8 @@ fn generate_command(mut inv: Invocation) -> Result<proc_macro2::TokenStream, dar
     let parameters = slash::generate_parameters(&inv)?;
     let ephemeral = inv.args.ephemeral;
     let custom_data = match &inv.args.custom_data {
-        Some(custom_data) => quote::quote! { Box::new(#custom_data) },
-        None => quote::quote! { Box::new(()) },
+        Some(custom_data) => quote::quote! { ::std::boxed::Box::new(#custom_data) },
+        None => quote::quote! { ::std::boxed::Box::new(()) },
     };
 
     let name_localizations = iter_tuple_2_to_hash_map(inv.args.name_localized.into_iter());
@@ -360,8 +364,8 @@ fn generate_command(mut inv: Invocation) -> Result<proc_macro2::TokenStream, dar
     Ok(quote::quote! {
         #[allow(clippy::str_to_string)]
         #function_visibility fn #function_ident #function_generics() -> ::poise::Command<
-            <#ctx_type_with_static as poise::_GetGenerics>::U,
-            <#ctx_type_with_static as poise::_GetGenerics>::E,
+            <#ctx_type_with_static as ::poise::_GetGenerics>::U,
+            <#ctx_type_with_static as ::poise::_GetGenerics>::E,
         > {
             #function
 
@@ -370,20 +374,20 @@ fn generate_command(mut inv: Invocation) -> Result<proc_macro2::TokenStream, dar
                 slash_action: #slash_action,
                 context_menu_action: #context_menu_action,
 
-                subcommands: vec![ #( #subcommands() ),* ],
+                subcommands: ::std::vec![ #( #subcommands() ),* ],
                 subcommand_required: #subcommand_required,
-                name: #command_name.to_string(),
+                name: ::std::string::ToString::to_string(#command_name),
                 name_localizations: #name_localizations,
-                qualified_name: String::from(#command_name), // properly filled in later by Framework
-                identifying_name: String::from(#identifying_name),
-                source_code_name: String::from(#function_name),
+                qualified_name: ::core::convert::From::from(#command_name), // properly filled in later by Framework
+                identifying_name: ::core::convert::From::from(#identifying_name),
+                source_code_name: ::core::convert::From::from(#function_name),
                 category: #category,
                 description: #description,
                 description_localizations: #description_localizations,
                 help_text: #help_text,
                 hide_in_help: #hide_in_help,
                 manual_cooldowns: #manual_cooldowns,
-                cooldowns: std::sync::Mutex::new(::poise::Cooldowns::new()),
+                cooldowns: ::std::sync::Mutex::new(::poise::Cooldowns::new()),
                 cooldown_config: #cooldown_config,
                 reuse_response: #reuse_response,
                 default_member_permissions: #default_member_permissions,
@@ -395,12 +399,12 @@ fn generate_command(mut inv: Invocation) -> Result<proc_macro2::TokenStream, dar
                 nsfw_only: #nsfw_only,
                 install_context: #install_context,
                 interaction_context: #interaction_context,
-                checks: vec![ #( |ctx| Box::pin(#checks(ctx)) ),* ],
+                checks: ::std::vec![ #( |ctx| ::std::boxed::Box::pin(#checks(ctx)) ),* ],
                 on_error: #on_error,
-                parameters: vec![ #( #parameters ),* ],
+                parameters: ::std::vec![ #( #parameters ),* ],
                 custom_data: #custom_data,
 
-                aliases: vec![ #( #aliases.to_string(), )* ],
+                aliases: ::std::vec![ #( ::std::string::ToString::to_string(#aliases), )* ],
                 invoke_on_edit: #invoke_on_edit,
                 track_deletion: #track_deletion,
                 broadcast_typing: #broadcast_typing,
@@ -424,10 +428,10 @@ fn generate_cooldown_config(args: &CommandArgs) -> proc_macro2::TokenStream {
     ];
 
     if all_cooldowns.iter().all(Option::is_none) {
-        return quote::quote!(std::sync::RwLock::default());
+        return quote::quote!(::core::default::Default::default());
     }
 
-    let to_seconds_path = quote::quote!(std::time::Duration::from_secs);
+    let to_seconds_path = quote::quote!(::std::time::Duration::from_secs);
 
     let global_cooldown = wrap_option_and_map(args.global_cooldown, &to_seconds_path);
     let user_cooldown = wrap_option_and_map(args.user_cooldown, &to_seconds_path);
@@ -436,7 +440,7 @@ fn generate_cooldown_config(args: &CommandArgs) -> proc_macro2::TokenStream {
     let member_cooldown = wrap_option_and_map(args.member_cooldown, &to_seconds_path);
 
     quote::quote!(
-        std::sync::RwLock::new(::poise::CooldownConfig {
+        ::std::sync::RwLock::new(::poise::CooldownConfig {
             global: #global_cooldown,
             user: #user_cooldown,
             guild: #guild_cooldown,

--- a/macros/src/command/prefix.rs
+++ b/macros/src/command/prefix.rs
@@ -52,13 +52,13 @@ pub fn generate_prefix_action(inv: &Invocation) -> Result<proc_macro2::TokenStre
     };
 
     Ok(quote::quote! {
-        |ctx| Box::pin(async move {
+        |ctx| ::std::boxed::Box::pin(async move {
             let ( #( #param_idents, )* .. ) = ::poise::parse_prefix_args!(
                 ctx.serenity_context, ctx.msg, ctx.args, 0 =>
                 #( #param_specs, )*
                 #wildcard_arg
-            ).await.map_err(|(error, input)| poise::FrameworkError::new_argument_parse(
-                ctx.into(),
+            ).await.map_err(|(error, input)| ::poise::FrameworkError::new_argument_parse(
+                ::core::convert::Into::into(ctx),
                 input,
                 error,
             ))?;
@@ -70,10 +70,10 @@ pub fn generate_prefix_action(inv: &Invocation) -> Result<proc_macro2::TokenStre
                 ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());
             }
 
-            inner(ctx.into(), #( #param_idents, )* )
+            inner(::core::convert::Into::into(ctx), #( #param_idents, )* )
                 .await
-                .map_err(|error| poise::FrameworkError::new_command(
-                    ctx.into(),
+                .map_err(|error| ::poise::FrameworkError::new_command(
+                    ::core::convert::Into::into(ctx),
                     error,
                 ))
         })

--- a/macros/src/command/slash.rs
+++ b/macros/src/command/slash.rs
@@ -33,22 +33,22 @@ pub fn generate_parameters(inv: &Invocation) -> Result<Vec<proc_macro2::TokenStr
         let autocomplete_callback = match &param.args.autocomplete {
             Some(autocomplete_fn) => {
                 quote::quote! { Some(|
-                    ctx: poise::ApplicationContext<'_, _, _>,
+                    ctx: ::poise::ApplicationContext<'_, _, _>,
                     partial: &str,
-                | Box::pin(async move {
+                | ::std::boxed::Box::pin(async move {
                     use ::poise::futures_util::{Stream, StreamExt};
 
                     let choices_stream = ::poise::into_stream!(
-                        #autocomplete_fn(ctx.into(), partial).await
+                        #autocomplete_fn(::core::convert::Into::into(ctx), partial).await
                     );
                     let choices_vec = choices_stream
                         .take(25)
                         // T or AutocompleteChoice<T> -> AutocompleteChoice<T>
-                        .map(poise::serenity_prelude::AutocompleteChoice::from)
+                        .map(::poise::serenity_prelude::AutocompleteChoice::from)
                         .collect()
                         .await;
 
-                    let mut response = poise::serenity_prelude::CreateAutocompleteResponse::default();
+                    let mut response = ::poise::serenity_prelude::CreateAutocompleteResponse::default();
                     Ok(response.set_choices(choices_vec))
                 })) }
             }
@@ -80,7 +80,7 @@ pub fn generate_parameters(inv: &Invocation) -> Result<Vec<proc_macro2::TokenStr
                     quote::quote! { Some(|o| o.kind(::poise::serenity_prelude::CommandOptionType::Integer)) }
                 } else {
                     quote::quote! { Some(|o| {
-                        poise::create_slash_argument!(#type_, o)
+                        ::poise::create_slash_argument!(#type_, o)
                         #min_value_setter #max_value_setter
                         #min_length_setter #max_length_setter
                     }) }
@@ -100,7 +100,7 @@ pub fn generate_parameters(inv: &Invocation) -> Result<Vec<proc_macro2::TokenStr
                         __non_exhaustive: (),
                     } ),*] }
                 } else {
-                    quote::quote! { poise::slash_argument_choices!(#type_) }
+                    quote::quote! { ::poise::slash_argument_choices!(#type_) }
                 }
             }
             false => quote::quote! { vec![] },
@@ -108,7 +108,7 @@ pub fn generate_parameters(inv: &Invocation) -> Result<Vec<proc_macro2::TokenStr
 
         let channel_types = match &param.args.channel_types {
             Some(crate::util::List(channel_types)) => quote::quote! { Some(
-                vec![ #( poise::serenity_prelude::ChannelType::#channel_types ),* ]
+                vec![ #( ::poise::serenity_prelude::ChannelType::#channel_types ),* ]
             ) },
             None => quote::quote! { None },
         };
@@ -175,7 +175,7 @@ pub fn generate_slash_action(inv: &Invocation) -> Result<proc_macro2::TokenStrea
         .collect::<Vec<_>>();
 
     Ok(quote::quote! {
-        |ctx| Box::pin(async move {
+        |ctx| ::std::boxed::Box::pin(async move {
             // idk why this can't be put in the macro itself (where the lint is triggered) and
             // why clippy doesn't turn off this lint inside macros in the first place
             #[allow(clippy::needless_question_mark)]
@@ -192,10 +192,10 @@ pub fn generate_slash_action(inv: &Invocation) -> Result<proc_macro2::TokenStrea
                 ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());
             }
 
-            inner(ctx.into(), #( #param_identifiers, )*)
+            inner(::core::convert::Into::into(ctx), #( #param_identifiers, )*)
                 .await
-                .map_err(|error| poise::FrameworkError::new_command(
-                    ctx.into(),
+                .map_err(|error| ::poise::FrameworkError::new_command(
+                    ::core::convert::Into::into(ctx),
                     error,
                 ))
         })
@@ -217,7 +217,7 @@ pub fn generate_context_menu_action(
 
     Ok(quote::quote! {
         <#param_type as ::poise::ContextMenuParameter<_, _>>::to_action(|ctx, value| {
-            Box::pin(async move {
+            ::std::boxed::Box::pin(async move {
                 let is_framework_cooldown = !ctx.command.manual_cooldowns
                     .unwrap_or_else(|| ctx.framework.options.manual_cooldowns);
 
@@ -225,10 +225,10 @@ pub fn generate_context_menu_action(
                     ctx.command.cooldowns.lock().unwrap().start_cooldown(ctx.cooldown_context());
                 }
 
-                inner(ctx.into(), value)
+                inner(::core::convert::Into::into(ctx), value)
                     .await
-                    .map_err(|error| poise::FrameworkError::new_command(
-                        ctx.into(),
+                    .map_err(|error| ::poise::FrameworkError::new_command(
+                        ::core::convert::Into::into(ctx),
                         error,
                     ))
             })

--- a/macros/src/modal.rs
+++ b/macros/src/modal.rs
@@ -91,7 +91,7 @@ pub fn modal(input: syn::DeriveInput) -> Result<TokenStream, darling::Error> {
             None
         };
         parsers.push(quote::quote! {
-            #field_ident: poise::find_modal_text(&mut data, stringify!(#field_ident)) #ok_or,
+            #field_ident: ::poise::find_modal_text(&mut data, stringify!(#field_ident)) #ok_or,
         });
     }
 
@@ -99,8 +99,8 @@ pub fn modal(input: syn::DeriveInput) -> Result<TokenStream, darling::Error> {
     let struct_ident = input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     Ok(quote::quote! { const _: () = {
-        use poise::serenity_prelude as serenity;
-        impl #impl_generics poise::Modal for #struct_ident #ty_generics #where_clause {
+        use ::poise::serenity_prelude as serenity;
+        impl #impl_generics ::poise::Modal for #struct_ident #ty_generics #where_clause {
             fn create(mut defaults: Option<Self>, custom_id: String) -> serenity::CreateInteractionResponse {
                 serenity::CreateInteractionResponse::Modal(
                     serenity::CreateModal::new(custom_id, #modal_title).components(vec!{#( #builders )*})

--- a/macros/src/util.rs
+++ b/macros/src/util.rs
@@ -21,8 +21,8 @@ pub fn extract_type_parameter<'a>(outer_type: &str, t: &'a syn::Type) -> Option<
 /// Converts None => `None` and Some(x) => `Some(#x)`
 pub fn wrap_option<T: quote::ToTokens>(literal: Option<T>) -> syn::Expr {
     match literal {
-        Some(literal) => syn::parse_quote! { Some(#literal) },
-        None => syn::parse_quote! { None },
+        Some(literal) => syn::parse_quote! { ::core::option::Option::Some(#literal) },
+        None => syn::parse_quote! { ::core::option::Option::None },
     }
 }
 
@@ -32,8 +32,8 @@ pub fn wrap_option_and_map<T: quote::ToTokens>(
     map_path: impl quote::ToTokens,
 ) -> syn::Expr {
     match literal {
-        Some(literal) => syn::parse_quote! { Some(#map_path(#literal)) },
-        None => syn::parse_quote! { None },
+        Some(literal) => syn::parse_quote! { ::core::option::Option::Some(#map_path(#literal)) },
+        None => syn::parse_quote! { ::core::option::Option::None },
     }
 }
 
@@ -105,7 +105,7 @@ where
     T: quote::ToTokens,
 {
     if v.len() == 0 {
-        return quote::quote!(std::collections::HashMap::new());
+        return quote::quote!(::std::collections::HashMap::new());
     }
 
     let (keys, values) = v
@@ -114,8 +114,8 @@ where
         .unzip::<_, _, Vec<_>, Vec<_>>();
 
     quote::quote! {
-        std::collections::HashMap::from([
-            #( (#keys.to_string(), #values.to_string()) ),*
+        ::core::convert::From::from([
+            #( (::std::string::ToString::to_string(#keys), ::std::string::ToString::to_string(#values)) ),*
         ])
     }
 }

--- a/src/prefix_argument/argument_trait.rs
+++ b/src/prefix_argument/argument_trait.rs
@@ -13,7 +13,7 @@ use std::marker::PhantomData;
 macro_rules! pop_prefix_argument {
     ($target:ty, $args:expr, $attachment_id:expr, $ctx:expr, $msg:expr) => {{
         use $crate::PopArgumentHack as _;
-        (&std::marker::PhantomData::<$target>).pop_from($args, $attachment_id, $ctx, $msg)
+        (&::std::marker::PhantomData::<$target>).pop_from($args, $attachment_id, $ctx, $msg)
     }};
 }
 

--- a/src/prefix_argument/macros.rs
+++ b/src/prefix_argument/macros.rs
@@ -7,7 +7,7 @@ macro_rules! _parse_prefix {
     // All arguments have been consumed
     ( $ctx:ident $msg:ident $args:ident $attachment_index:ident => [ $error:ident $( $name:ident )* ] ) => {
         if $args.is_empty() {
-            return Ok(( $( $name, )* ));
+            return ::core::result::Result::Ok(( $( $name, )* ));
         }
     };
 
@@ -157,10 +157,10 @@ macro_rules! _parse_prefix {
         $( $rest:tt )*
     ) => {
         match $crate::pop_prefix_argument!($type, &$args, $attachment_index, $ctx, $msg).await {
-            Ok(($args, $attachment_index, token)) => {
+            ::core::result::Result::Ok(($args, $attachment_index, token)) => {
                 $crate::_parse_prefix!($ctx $msg $args $attachment_index => [ $error $($preamble)* token ] $($rest)* );
             },
-            Err(e) => $error = e,
+            ::core::result::Result::Err(e) => $error = e,
         }
     };
 
@@ -229,8 +229,8 @@ macro_rules! parse_prefix_args {
             let args = $args;
             let attachment_index = $attachment_index;
 
-            let mut error: (Box<dyn std::error::Error + Send + Sync>, Option<String>)
-                = (Box::new($crate::TooManyArguments { __non_exhaustive: () }) as _, None);
+            let mut error: (::std::boxed::Box<dyn ::std::error::Error + ::core::marker::Send + ::core::marker::Sync>, ::core::option::Option<::std::string::String>)
+                = (::std::boxed::Box::new($crate::TooManyArguments { __non_exhaustive: () }) as _, ::core::option::Option::None);
 
             $crate::_parse_prefix!(
                 ctx msg args attachment_index => [error]
@@ -238,7 +238,7 @@ macro_rules! parse_prefix_args {
                     ($( #[$attr] )? $($type)*)
                 )*
             );
-            Err(error)
+            ::core::result::Result::Err(error)
         }
     };
 }

--- a/src/slash_argument/slash_macro.rs
+++ b/src/slash_argument/slash_macro.rs
@@ -114,47 +114,47 @@ impl std::error::Error for SlashArgError {
 macro_rules! _parse_slash {
     // Extract #[choices(...)] (no Option supported ;-;)
     ($ctx:ident, $interaction:ident, $args:ident => $name:literal: INLINE_CHOICE $type:ty [$($index:literal: $value:literal),*]) => {
-        if let Some(arg) = $args.iter().find(|arg| arg.name == $name) {
+        if let ::core::option::Option::Some(arg) = $args.iter().find(|arg| arg.name == $name) {
             let $crate::serenity_prelude::ResolvedValue::Integer(index) = arg.value else {
-                return Err($crate::SlashArgError::new_command_structure_mismatch("expected integer, as the index for an inline choice parameter"));
+                return ::core::result::Result::Err($crate::SlashArgError::new_command_structure_mismatch("expected integer, as the index for an inline choice parameter"));
             };
             match index {
                 $( $index => $value, )*
-                _ => return Err($crate::SlashArgError::new_command_structure_mismatch("out of range index for inline choice parameter")),
+                _ => return ::core::result::Result::Err($crate::SlashArgError::new_command_structure_mismatch("out of range index for inline choice parameter")),
             }
         } else {
-            return Err($crate::SlashArgError::new_command_structure_mismatch("a required argument is missing"));
+            return ::core::result::Result::Err($crate::SlashArgError::new_command_structure_mismatch("a required argument is missing"));
         }
     };
 
     // Extract Option<T>
     ($ctx:ident, $interaction:ident, $args:ident => $name:literal: Option<$type:ty $(,)*>) => {
-        if let Some(arg) = $args.iter().find(|arg| arg.name == $name) {
-            Some($crate::extract_slash_argument!($type, $ctx, $interaction, &arg.value)
+        if let ::core::option::Option::Some(arg) = $args.iter().find(|arg| arg.name == $name) {
+            ::core::option::Option::Some($crate::extract_slash_argument!($type, $ctx, $interaction, &arg.value)
                 .await?)
         } else {
-            None
+            ::core::option::Option::None
         }
     };
 
     // Extract Vec<T> (delegating to Option<T> because slash commands don't support variadic
     // arguments right now)
     ($ctx:ident, $interaction:ident, $args:ident => $name:literal: Vec<$type:ty $(,)*>) => {
-        match $crate::_parse_slash!($ctx, $interaction, $args => $name: Option<$type>) {
-            Some(value) => vec![value],
-            None => vec![],
+        match $crate::_parse_slash!($ctx, $interaction, $args => $name: ::core::option::Option<$type>) {
+            ::core::option::Option::Some(value) => ::std::vec![value],
+            ::core::option::Option::None => ::std::vec![],
         }
     };
 
     // Extract #[flag]
     ($ctx:ident, $interaction:ident, $args:ident => $name:literal: FLAG) => {
-        $crate::_parse_slash!($ctx, $interaction, $args => $name: Option<bool>)
+        $crate::_parse_slash!($ctx, $interaction, $args => $name: ::core::option::Option<bool>)
             .unwrap_or(false)
     };
 
     // Extract T
     ($ctx:ident, $interaction:ident, $args:ident => $name:literal: $($type:tt)*) => {
-        $crate::_parse_slash!($ctx, $interaction, $args => $name: Option<$($type)*>)
+        $crate::_parse_slash!($ctx, $interaction, $args => $name: ::core::option::Option<$($type)*>)
             .ok_or($crate::SlashArgError::new_command_structure_mismatch("a required argument is missing"))?
     };
 }
@@ -192,7 +192,7 @@ macro_rules! parse_slash_args {
             // ctx here is a serenity::Context, so it doesn't already contain interaction!
             let (ctx, interaction, args) = ($ctx, $interaction, $args);
 
-            Ok::<_, $crate::SlashArgError>(( $(
+            ::core::result::Result::Ok::<_, $crate::SlashArgError>(( $(
                 $crate::_parse_slash!( ctx, interaction, args => $name: $($type)* ),
             )* ))
         }


### PR DESCRIPTION
Simply modifies macro output to generate fully qualified paths such as `::core::option::Option::Some` instead of `Some` as recommended in macros, allowing the use of `#[command]` in crates with the attribute #![no_implicit_prelude] without missing import errors.