### PR TITLE
docs: Add 'Claude Bot' to bots using poise in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For each bot, there's a list of notable features for you to take inspiration fro
 - [Rustbot](https://github.com/rust-community-discord/ferrisbot-for-discord) by [@kangalio](https://github.com/kangalio): database, custom prefixes
 - [StatPixel](https://github.com/statpixel-rs/statpixel) by [@matteopolak](https://github.com/matteopolak): modals, buttons, dropdowns, database, localization
 - [CrackTunes](https://github.com/cycle-five/cracktunes) by [@cycle-five](https://github.com/cycle-five): database, voice, custom prefixes, modals.
+- [Claude Bot](https://github.com/wyatt-avilla/claude-discord-bot) by [@wyatt-avilla](https://github.com/wyatt-avilla): database, reactions, slash commands, attachments.
 
 You're welcome to add your own bot [via a PR](https://github.com/serenity-rs/poise/compare)!
 


### PR DESCRIPTION
Thanks for poise! It made writing my bot really enjoyable.

This PR adds a link to the bot in the `Bots using poise` section of the readme.

I'm open to any suggestions/critiques on the notable features that I listed.

[Here's the repo for the bot.](https://github.com/wyatt-avilla/claude-discord-bot)
