### PR TITLE
Make error replies ephemeral

### DIFF
--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -59,7 +59,8 @@ pub async fn on_error<U, E: std::fmt::Display + std::fmt::Debug>(
             ctx.send(
                 CreateReply::default()
                     .content(error)
-                    .allowed_mentions(mentions),
+                    .allowed_mentions(mentions)
+                    .ephemeral(true),
             )
             .await?;
         }
@@ -111,7 +112,8 @@ pub async fn on_error<U, E: std::fmt::Display + std::fmt::Debug>(
             ctx.send(
                 CreateReply::default()
                     .content(response)
-                    .allowed_mentions(mentions),
+                    .allowed_mentions(mentions)
+                    .ephemeral(true),
             )
             .await?;
         }


### PR DESCRIPTION
This might remove the need for #277.

Feel free to reject if there's a particular reason for these to be non-ephemeral.
