### PR TITLE
Add `ArgumentConvert` trait from serenity to fix breakage

### DIFF
--- a/.github/Cargo-msrv.lock
+++ b/.github/Cargo-msrv.lock
@@ -1509,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "serenity"
 version = "0.12.4"
-source = "git+https://github.com/serenity-rs/serenity?branch=next#3009d22082cadab93e0f463e9d9868b656cd62bc"
+source = "git+https://github.com/serenity-rs/serenity?branch=next#e801f3a4609d46c09f2c0a6124156a5994bb398a"
 dependencies = [
  "aformat",
  "arrayvec",
@@ -1579,9 +1579,9 @@ checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "small-fixed-array"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8311fa212af82bdee69d5332af52dc8b09e77f5777258999a9339adfe2d345f9"
+checksum = "f47eb472ef0994fb63d68ce4851eef89fa0faaf0dc4088c941b4015ce32c083f"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "serenity"
 version = "0.12.4"
-source = "git+https://github.com/serenity-rs/serenity?branch=next#3009d22082cadab93e0f463e9d9868b656cd62bc"
+source = "git+https://github.com/serenity-rs/serenity?branch=next#e801f3a4609d46c09f2c0a6124156a5994bb398a"
 dependencies = [
  "aformat",
  "arrayvec",
@@ -1579,9 +1579,9 @@ checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "small-fixed-array"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8311fa212af82bdee69d5332af52dc8b09e77f5777258999a9339adfe2d345f9"
+checksum = "f47eb472ef0994fb63d68ce4851eef89fa0faaf0dc4088c941b4015ce32c083f"
 dependencies = [
  "serde",
 ]

--- a/examples/feature_showcase/main.rs
+++ b/examples/feature_showcase/main.rs
@@ -99,11 +99,7 @@ async fn main() {
                 println!("what the hell");
                 match error {
                     poise::FrameworkError::ArgumentParse { error, .. } => {
-                        if let Some(error) = error.downcast_ref::<serenity::RoleParseError>() {
-                            println!("Found a RoleParseError: {:?}", error);
-                        } else {
-                            println!("Not a RoleParseError :(");
-                        }
+                        println!("Parse error: {error:?}")
                     }
                     other => poise::builtins::on_error(other).await.unwrap(),
                 }

--- a/macros/src/command/prefix.rs
+++ b/macros/src/command/prefix.rs
@@ -133,7 +133,7 @@ fn parse_rest(
         if input.is_empty() {
             #fail
         } else {
-            match <#ty as ::poise::serenity_prelude::ArgumentConvert>::convert(
+            match <#ty as ::poise::ArgumentConvert>::convert(
                 serenity_ctx, msg.guild_id, Some(msg.channel_id), input
             ).await {
                 Ok(#token) => {

--- a/src/argument_convert/channel.rs
+++ b/src/argument_convert/channel.rs
@@ -1,0 +1,176 @@
+//! Contains implementations of [`ArgumentConvert`] for [`serenity::Channel`] and
+//! [`serenity::GuildChannel`].
+
+use std::fmt;
+
+use super::ArgumentConvert;
+use crate::serenity_prelude as serenity;
+
+/// Error that can be returned from [`serenity::Channel::convert`].
+#[derive(Debug)]
+pub enum ChannelParseError {
+    /// When channel retrieval via HTTP failed
+    Http(serenity::Error),
+    /// The provided channel string failed to parse, or the parsed result cannot be found in the
+    /// cache.
+    NotFoundOrMalformed,
+}
+
+impl std::error::Error for ChannelParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Http(e) => Some(e),
+            Self::NotFoundOrMalformed => None,
+        }
+    }
+}
+
+impl fmt::Display for ChannelParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Http(_) => f.write_str("Failed to request channel via HTTP"),
+            Self::NotFoundOrMalformed => f.write_str("Channel not found or unknown format"),
+        }
+    }
+}
+
+/// Performs a lookup for a channel.
+async fn lookup_channel_global(
+    ctx: impl serenity::CacheHttp,
+    guild_id: Option<serenity::GuildId>,
+    s: &str,
+) -> Result<serenity::Channel, ChannelParseError> {
+    if let Some(channel_id) = s
+        .parse()
+        .ok()
+        .or_else(|| serenity::utils::parse_channel_mention(s))
+        .or_else(|| serenity::utils::parse_channel_url(s).map(|(_, channel_id)| channel_id))
+    {
+        return channel_id
+            .to_channel(ctx, guild_id)
+            .await
+            .map_err(ChannelParseError::Http);
+    }
+
+    let guild_id = guild_id.ok_or(ChannelParseError::NotFoundOrMalformed)?;
+
+    #[cfg(feature = "cache")]
+    if let Some(cache) = ctx.cache() {
+        if let Some(guild) = cache.guild(guild_id) {
+            let channel = guild
+                .channels
+                .iter()
+                .find(|c| c.base.name.eq_ignore_ascii_case(s));
+            if let Some(channel) = channel {
+                return Ok(serenity::Channel::Guild(channel.clone()));
+            }
+        }
+
+        return Err(ChannelParseError::NotFoundOrMalformed);
+    }
+
+    let channels = ctx
+        .http()
+        .get_channels(guild_id)
+        .await
+        .map_err(ChannelParseError::Http)?;
+    if let Some(channel) = channels
+        .into_iter()
+        .find(|c| c.base.name.eq_ignore_ascii_case(s))
+    {
+        Ok(serenity::Channel::Guild(channel))
+    } else {
+        Err(ChannelParseError::NotFoundOrMalformed)
+    }
+}
+
+/// Look up a Channel by a string case-insensitively.
+///
+/// Lookup are done via local guild. If in DMs, the global cache is used instead.
+///
+/// The cache feature needs to be enabled.
+///
+/// The lookup strategy is as follows (in order):
+/// 1. Lookup by ID.
+/// 2. [Lookup by mention](serenity::utils::parse_channel_mention).
+/// 3. Lookup by name.
+#[async_trait::async_trait]
+impl ArgumentConvert for serenity::Channel {
+    type Err = ChannelParseError;
+
+    async fn convert(
+        ctx: impl serenity::CacheHttp,
+        guild_id: Option<serenity::GuildId>,
+        _: Option<serenity::GenericChannelId>,
+        s: &str,
+    ) -> Result<Self, Self::Err> {
+        let channel = lookup_channel_global(&ctx, guild_id, s).await?;
+
+        // Don't yield for other guilds' channels
+        if let Some(guild_id) = guild_id {
+            if channel.guild_id().is_none_or(|id| id != guild_id) {
+                return Err(ChannelParseError::NotFoundOrMalformed);
+            }
+        }
+
+        Ok(channel)
+    }
+}
+
+/// Error that can be returned from [`serenity::GuildChannel::convert`].
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum GuildChannelParseError {
+    /// When channel retrieval via HTTP failed
+    Http(serenity::Error),
+    /// The provided channel string failed to parse, or the parsed result cannot be found in the
+    /// cache.
+    NotFoundOrMalformed,
+    /// When the referenced channel is not a guild channel
+    NotAGuildChannel,
+}
+
+impl std::error::Error for GuildChannelParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Http(e) => Some(e),
+            Self::NotFoundOrMalformed | Self::NotAGuildChannel => None,
+        }
+    }
+}
+
+impl fmt::Display for GuildChannelParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Http(_) => f.write_str("Failed to request channel via HTTP"),
+            Self::NotFoundOrMalformed => f.write_str("Channel not found or unknown format"),
+            Self::NotAGuildChannel => f.write_str("Channel is not a guild channel"),
+        }
+    }
+}
+
+/// Look up a GuildChannel by a string case-insensitively.
+///
+/// Lookup is done by the global cache, hence the cache feature needs to be enabled.
+///
+/// For more information, see the ArgumentConvert implementation for [`Channel`]
+#[async_trait::async_trait]
+impl ArgumentConvert for serenity::GuildChannel {
+    type Err = GuildChannelParseError;
+
+    async fn convert(
+        ctx: impl serenity::CacheHttp,
+        guild_id: Option<serenity::GuildId>,
+        channel_id: Option<serenity::GenericChannelId>,
+        s: &str,
+    ) -> Result<Self, Self::Err> {
+        match serenity::Channel::convert(&ctx, guild_id, channel_id, s).await {
+            Ok(serenity::Channel::Guild(channel)) => Ok(channel),
+            Ok(_) => Err(GuildChannelParseError::NotAGuildChannel),
+            Err(ChannelParseError::Http(e)) => Err(GuildChannelParseError::Http(e)),
+            Err(ChannelParseError::NotFoundOrMalformed) => {
+                Err(GuildChannelParseError::NotFoundOrMalformed)
+            }
+        }
+    }
+}

--- a/src/argument_convert/emoji.rs
+++ b/src/argument_convert/emoji.rs
@@ -1,0 +1,93 @@
+//! Contains implementations of [`ArgumentConvert`] for [`serenity::Emoji`] and
+//! [`serenity::EmojiId`].
+
+use std::fmt;
+use std::str::FromStr;
+
+use super::ArgumentConvert;
+use crate::serenity_prelude as serenity;
+
+/// Error that can be returned from [`serenity::Emoji::convert`].
+#[derive(Debug)]
+pub enum EmojiParseError {
+    /// Parser was invoked outside a guild.
+    OutsideGuild,
+    /// Guild was not in cache, or guild HTTP request failed.
+    FailedToRetrieveGuild,
+    /// The provided emoji string failed to parse, or the parsed result cannot be found in the
+    /// guild roles.
+    NotFoundOrMalformed,
+}
+
+impl std::error::Error for EmojiParseError {}
+
+impl fmt::Display for EmojiParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OutsideGuild => f.write_str("Tried to find emoji outside a guild"),
+            Self::FailedToRetrieveGuild => f.write_str("Could not retrieve guild data"),
+            Self::NotFoundOrMalformed => f.write_str("Emoji not found or unknown format"),
+        }
+    }
+}
+
+/// Look up a [`Emoji`].
+///
+/// Requires the cache feature to be enabled.
+///
+/// The lookup strategy is as follows (in order):
+/// 1. Lookup by ID.
+/// 2. [Lookup by extracting ID from the emoji](`crate::utils::parse_emoji`).
+/// 3. Lookup by name.
+#[async_trait::async_trait]
+impl ArgumentConvert for serenity::Emoji {
+    type Err = EmojiParseError;
+
+    async fn convert(
+        ctx: impl serenity::CacheHttp,
+        guild_id: Option<serenity::GuildId>,
+        _: Option<serenity::GenericChannelId>,
+        s: &str,
+    ) -> Result<Self, Self::Err> {
+        // Get Guild or PartialGuild
+        let guild_id = guild_id.ok_or(EmojiParseError::OutsideGuild)?;
+        let guild = guild_id
+            .to_partial_guild(&ctx)
+            .await
+            .map_err(|_| EmojiParseError::FailedToRetrieveGuild)?;
+
+        let direct_id = s.parse().ok();
+        let id_from_mention = serenity::utils::parse_emoji(s).map(|e| e.id);
+
+        if let Some(emoji_id) = direct_id.or(id_from_mention) {
+            if let Some(emoji) = guild.emojis.get(&emoji_id).cloned() {
+                return Ok(emoji);
+            }
+        }
+
+        if let Some(emoji) = guild
+            .emojis
+            .iter()
+            .find(|emoji| emoji.name.eq_ignore_ascii_case(s))
+            .cloned()
+        {
+            return Ok(emoji);
+        }
+
+        Err(EmojiParseError::NotFoundOrMalformed)
+    }
+}
+
+#[async_trait::async_trait]
+impl ArgumentConvert for serenity::EmojiId {
+    type Err = <serenity::EmojiId as FromStr>::Err;
+
+    async fn convert(
+        _: impl serenity::CacheHttp,
+        _: Option<serenity::GuildId>,
+        _: Option<serenity::GenericChannelId>,
+        s: &str,
+    ) -> Result<Self, Self::Err> {
+        s.parse()
+    }
+}

--- a/src/argument_convert/guild.rs
+++ b/src/argument_convert/guild.rs
@@ -1,0 +1,75 @@
+//! Contains implementations of [`ArgumentConvert`] for [`serenity::Guild`] and
+//! [`serenity::GuildId`].
+
+use std::fmt;
+use std::str::FromStr;
+
+use super::ArgumentConvert;
+use crate::serenity_prelude as serenity;
+
+/// Error that can be returned from [`serenity::Guild::convert`].
+#[derive(Debug)]
+pub enum GuildParseError {
+    /// The parsed guild id could not be found in the cache.
+    NotFound,
+    /// The provided guild Id failed to parse.
+    Malformed(serenity::ParseIdError),
+    /// No cache, so no guild search could be done.
+    NoCache,
+}
+
+impl std::error::Error for GuildParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Malformed(e) => Some(e),
+            Self::NotFound | Self::NoCache => None,
+        }
+    }
+}
+
+impl fmt::Display for GuildParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound => f.write_str("Guild not found"),
+            Self::Malformed(_) => f.write_str("Unknown format for guild id"),
+            Self::NoCache => f.write_str("No cached list of guilds was provided"),
+        }
+    }
+}
+
+/// Look up a Guild by Id.
+///
+/// Requires the cache feature to be enabled.
+#[cfg(feature = "cache")]
+#[async_trait::async_trait]
+impl ArgumentConvert for serenity::Guild {
+    type Err = GuildParseError;
+
+    async fn convert(
+        ctx: impl serenity::CacheHttp,
+        _: Option<serenity::GuildId>,
+        _: Option<serenity::GenericChannelId>,
+        s: &str,
+    ) -> Result<Self, Self::Err> {
+        let cache = ctx.cache().ok_or(GuildParseError::NoCache)?;
+        let guild_id = s.parse().map_err(GuildParseError::Malformed)?;
+        cache
+            .guild(guild_id)
+            .map(|g| g.clone())
+            .ok_or(GuildParseError::NotFound)
+    }
+}
+
+#[async_trait::async_trait]
+impl ArgumentConvert for serenity::GuildId {
+    type Err = <serenity::EmojiId as FromStr>::Err;
+
+    async fn convert(
+        _: impl serenity::CacheHttp,
+        _: Option<serenity::GuildId>,
+        _: Option<serenity::GenericChannelId>,
+        s: &str,
+    ) -> Result<Self, Self::Err> {
+        s.parse()
+    }
+}

--- a/src/argument_convert/member.rs
+++ b/src/argument_convert/member.rs
@@ -1,0 +1,91 @@
+//! Contains the implementation of [`ArgumentConvert`] for [`serenity::Member`].
+
+use std::fmt;
+
+use super::ArgumentConvert;
+use crate::serenity_prelude as serenity;
+
+/// Error that can be returned from [`serenity::Member::convert`].
+#[derive(Debug)]
+pub enum MemberParseError {
+    /// Parser was invoked outside a guild.
+    OutsideGuild,
+    /// The guild in which the parser was invoked is not in cache.
+    GuildNotInCache,
+    /// The provided member string failed to parse, or the parsed result cannot be found in the
+    /// guild cache data.
+    NotFoundOrMalformed,
+}
+
+impl std::error::Error for MemberParseError {}
+
+impl fmt::Display for MemberParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OutsideGuild => f.write_str("Tried to find member outside a guild"),
+            Self::GuildNotInCache => f.write_str("Guild is not in cache"),
+            Self::NotFoundOrMalformed => f.write_str("Member not found or unknown format"),
+        }
+    }
+}
+
+/// Look up a guild member by a string case-insensitively.
+///
+/// Requires the cache feature to be enabled.
+///
+/// The lookup strategy is as follows (in order):
+/// 1. Lookup by ID.
+/// 2. [Lookup by mention](`serenity::utils::parse_user_mention`).
+/// 3. [Lookup by name#discrim](`serenity::utils::parse_user_tag`).
+/// 4. Lookup by name
+/// 5. Lookup by nickname
+#[async_trait::async_trait]
+impl ArgumentConvert for serenity::Member {
+    type Err = MemberParseError;
+
+    async fn convert(
+        ctx: impl serenity::CacheHttp,
+        guild_id: Option<serenity::GuildId>,
+        _: Option<serenity::GenericChannelId>,
+        s: &str,
+    ) -> Result<Self, Self::Err> {
+        let guild_id = guild_id.ok_or(MemberParseError::OutsideGuild)?;
+
+        // If string is a raw user ID or a mention
+        if let Some(user_id) = s
+            .parse()
+            .ok()
+            .or_else(|| serenity::utils::parse_user_mention(s))
+        {
+            if let Ok(member) = guild_id.member(&ctx, user_id).await {
+                return Ok(member);
+            }
+        }
+
+        // If string is a username+discriminator
+        let limit = Some(100u8.into());
+        if let Some((name, discrim)) = serenity::utils::parse_user_tag(s) {
+            if let Ok(member_results) = guild_id.search_members(ctx.http(), name, limit).await {
+                if let Some(member) = member_results.into_iter().find(|m| {
+                    m.user.name.eq_ignore_ascii_case(name) && m.user.discriminator == discrim
+                }) {
+                    return Ok(member);
+                }
+            }
+        }
+
+        // If string is username or nickname
+        if let Ok(member_results) = guild_id.search_members(ctx.http(), s, limit).await {
+            if let Some(member) = member_results.into_iter().find(|m| {
+                m.user.name.eq_ignore_ascii_case(s)
+                    || m.nick
+                        .as_ref()
+                        .is_some_and(|nick| nick.eq_ignore_ascii_case(s))
+            }) {
+                return Ok(member);
+            }
+        }
+
+        Err(MemberParseError::NotFoundOrMalformed)
+    }
+}

--- a/src/argument_convert/message.rs
+++ b/src/argument_convert/message.rs
@@ -1,0 +1,76 @@
+//! Contains the implementation of [`ArgumentConvert`] for [`serenity::Message`].
+
+use std::fmt;
+
+use super::ArgumentConvert;
+use crate::serenity_prelude as serenity;
+
+/// Error that can be returned from [`serenity::Message::convert`].
+#[derive(Debug)]
+pub enum MessageParseError {
+    /// When the provided string does not adhere to any known guild message format
+    Malformed,
+    /// When message data retrieval via HTTP failed
+    Http(serenity::Error),
+    /// When the `gateway` feature is disabled and the required information was not in cache.
+    HttpNotAvailable,
+}
+
+impl std::error::Error for MessageParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Http(e) => Some(e),
+            Self::HttpNotAvailable | Self::Malformed => None,
+        }
+    }
+}
+
+impl fmt::Display for MessageParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Malformed => {
+                f.write_str("Provided string did not adhere to any known guild message format")
+            }
+            Self::Http(_) => f.write_str("Failed to request message data via HTTP"),
+            Self::HttpNotAvailable => f.write_str(
+                "Gateway feature is disabled and the required information was not in cache",
+            ),
+        }
+    }
+}
+
+/// Look up a message by a string.
+///
+/// The lookup strategy is as follows (in order):
+/// 1. [Lookup by "{channel ID}-{message ID}"](`crate::utils::parse_message_id_pair`) (retrieved by
+///    shift-clicking on "Copy ID")
+/// 2. Lookup by message ID (the message must be in the context channel)
+/// 3. [Lookup by message URL](`crate::utils::parse_message_url`)
+#[async_trait::async_trait]
+impl ArgumentConvert for serenity::Message {
+    type Err = MessageParseError;
+
+    async fn convert(
+        ctx: impl serenity::CacheHttp,
+        _: Option<serenity::GuildId>,
+        channel_id: Option<serenity::GenericChannelId>,
+        s: &str,
+    ) -> Result<Self, Self::Err> {
+        let extract_from_message_id = || Some((channel_id?, s.parse().ok()?));
+
+        let extract_from_message_url = || {
+            let (_guild_id, channel_id, message_id) = serenity::utils::parse_message_url(s)?;
+            Some((channel_id, message_id))
+        };
+
+        let (channel_id, message_id) = serenity::utils::parse_message_id_pair(s)
+            .or_else(extract_from_message_id)
+            .or_else(extract_from_message_url)
+            .ok_or(MessageParseError::Malformed)?;
+
+        channel_id
+            .message(ctx, message_id)
+            .await
+            .map_err(MessageParseError::Http)
+    }
+}

--- a/src/argument_convert/mod.rs
+++ b/src/argument_convert/mod.rs
@@ -1,0 +1,48 @@
+//! Contains the [`ArgumentConvert`] trait and implementations.
+
+mod channel;
+mod emoji;
+mod guild;
+mod member;
+mod message;
+mod role;
+mod user;
+
+use crate::serenity_prelude as serenity;
+
+/// Parse a value from a string in the context of a received message.
+///
+/// This trait is similar to [`std::str::FromStr`]. The difference is that this trait supports
+/// Discord-specific types like [`Member`] or [`Message`].
+///
+/// Trait implementations may perform network requests during parsing.
+///
+/// [`Member`]: crate::serenity_prelude::Member
+/// [`Message`]: crate::serenity_prelude::Message
+#[async_trait::async_trait]
+pub trait ArgumentConvert: Sized {
+    /// The associated error which can be returned from parsing.
+    type Err: std::error::Error + Send + Sync + 'static;
+
+    /// Parses a string `s` as a command parameter of this type.
+    async fn convert(
+        ctx: impl serenity::CacheHttp,
+        guild_id: Option<serenity::GuildId>,
+        channel_id: Option<serenity::GenericChannelId>,
+        s: &str,
+    ) -> Result<Self, Self::Err>;
+}
+
+#[async_trait::async_trait]
+impl ArgumentConvert for String {
+    type Err = std::convert::Infallible;
+
+    async fn convert(
+        _: impl serenity::CacheHttp,
+        _: Option<serenity::GuildId>,
+        _: Option<serenity::GenericChannelId>,
+        s: &str,
+    ) -> Result<Self, Self::Err> {
+        Ok(s.to_owned())
+    }
+}

--- a/src/argument_convert/role.rs
+++ b/src/argument_convert/role.rs
@@ -1,0 +1,108 @@
+//! Contains the implementation of [`ArgumentConvert`] for [`serenity::Role`].
+
+use std::fmt;
+
+use super::ArgumentConvert;
+use crate::serenity_prelude as serenity;
+
+/// Error that can be returned from [`serenity::Role::convert`].
+#[derive(Debug)]
+pub enum RoleParseError {
+    /// When the operation was invoked outside a guild.
+    NotInGuild,
+    /// When the guild's roles were not found in cache.
+    NotInCache,
+    /// HTTP error while retrieving guild roles.
+    Http(serenity::Error),
+    /// The provided channel string failed to parse, or the parsed result cannot be found in the
+    /// cache.
+    NotFoundOrMalformed,
+}
+
+impl std::error::Error for RoleParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Http(e) => Some(e),
+            Self::NotFoundOrMalformed | Self::NotInGuild | Self::NotInCache => None,
+        }
+    }
+}
+
+impl fmt::Display for RoleParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotInGuild => f.write_str("Must invoke this operation in a guild"),
+            Self::NotInCache => f.write_str("Guild's roles were not found in cache"),
+            Self::Http(_) => f.write_str("Failed to retrieve roles via HTTP"),
+            Self::NotFoundOrMalformed => f.write_str("Role not found or unknown format"),
+        }
+    }
+}
+
+/// Look up a [`Role`] by a string case-insensitively.
+///
+/// Requires the cache feature to be enabled.
+///
+/// The lookup strategy is as follows (in order):
+/// 1. Lookup by ID
+/// 2. [Lookup by mention](`crate::utils::parse_role_mention`).
+/// 3. Lookup by name (case-insensitive)
+#[async_trait::async_trait]
+impl ArgumentConvert for serenity::Role {
+    type Err = RoleParseError;
+
+    async fn convert(
+        ctx: impl serenity::CacheHttp,
+        guild_id: Option<serenity::GuildId>,
+        _: Option<serenity::GenericChannelId>,
+        s: &str,
+    ) -> Result<Self, Self::Err> {
+        let guild_id = guild_id.ok_or(RoleParseError::NotInGuild)?;
+
+        #[cfg(feature = "cache")]
+        let guild;
+
+        #[cfg(feature = "cache")]
+        let roles = {
+            let cache = ctx.cache().ok_or(RoleParseError::NotInCache)?;
+            guild = cache.guild(guild_id).ok_or(RoleParseError::NotInCache)?;
+            &guild.roles
+        };
+
+        #[cfg(not(feature = "cache"))]
+        let roles = ctx
+            .http()
+            .get_guild_roles(guild_id)
+            .await
+            .map_err(RoleParseError::Http)?;
+
+        if let Some(role_id) = s
+            .parse()
+            .ok()
+            .or_else(|| serenity::utils::parse_role_mention(s))
+        {
+            #[cfg(feature = "cache")]
+            if let Some(role) = roles.get(&role_id) {
+                return Ok(role.clone());
+            }
+            #[cfg(not(feature = "cache"))]
+            if let Some(role) = roles.iter().find(|role| role.id == role_id) {
+                return Ok(role.clone());
+            }
+        }
+
+        #[cfg(feature = "cache")]
+        if let Some(role) = roles.iter().find(|role| role.name.eq_ignore_ascii_case(s)) {
+            return Ok(role.clone());
+        }
+        #[cfg(not(feature = "cache"))]
+        if let Some(role) = roles
+            .into_iter()
+            .find(|role| role.name.eq_ignore_ascii_case(s))
+        {
+            return Ok(role);
+        }
+
+        Err(RoleParseError::NotFoundOrMalformed)
+    }
+}

--- a/src/argument_convert/user.rs
+++ b/src/argument_convert/user.rs
@@ -1,0 +1,56 @@
+//! Contains the implementation of [`ArgumentConvert`] for [`serenity::User`].
+
+use std::fmt;
+
+use super::ArgumentConvert;
+use crate::serenity_prelude as serenity;
+
+/// Error that can be returned from [`serenity::User::convert`].
+#[derive(Debug)]
+pub enum UserParseError {
+    /// The provided user string failed to parse, or the parsed result cannot be found in the guild
+    /// cache data.
+    NotFoundOrMalformed,
+}
+
+impl std::error::Error for UserParseError {}
+
+impl fmt::Display for UserParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFoundOrMalformed => f.write_str("User not found or unknown format"),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ArgumentConvert for serenity::User {
+    type Err = UserParseError;
+
+    async fn convert(
+        ctx: impl serenity::CacheHttp,
+        guild_id: Option<serenity::GuildId>,
+        channel_id: Option<serenity::GenericChannelId>,
+        s: &str,
+    ) -> Result<Self, Self::Err> {
+        // Convert as a Member which uses HTTP endpoints instead of cache
+        if let Ok(member) = serenity::Member::convert(&ctx, guild_id, channel_id, s).await {
+            return Ok(member.user);
+        }
+
+        // If string is a raw user ID or a mention
+        if let Some(user_id) = s
+            .parse()
+            .ok()
+            .or_else(|| serenity::utils::parse_user_mention(s))
+        {
+            // Now, we can still try UserId::to_user because it works for all users from all guilds
+            // the bot is joined
+            if let Ok(user) = user_id.to_user(&ctx).await {
+                return Ok(user);
+            }
+        }
+
+        Err(UserParseError::NotFoundOrMalformed)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,6 +377,7 @@ underlying this framework, so that's what I chose.
 Also, poise is a stat in Dark Souls
 */
 
+mod argument_convert;
 pub mod builtins;
 pub mod choice_parameter;
 pub mod cooldown;
@@ -396,8 +397,8 @@ pub mod macros {
 
 #[doc(no_inline)]
 pub use {
-    choice_parameter::*, cooldown::*, dispatch::*, framework::*, macros::*, modal::*,
-    prefix_argument::*, reply::*, slash_argument::*, structs::*, track_edits::*,
+    argument_convert::*, choice_parameter::*, cooldown::*, dispatch::*, framework::*, macros::*,
+    modal::*, prefix_argument::*, reply::*, slash_argument::*, structs::*, track_edits::*,
 };
 
 /// See [`builtins`]

--- a/src/prefix_argument/argument_trait.rs
+++ b/src/prefix_argument/argument_trait.rs
@@ -1,9 +1,9 @@
 //! Trait implemented for all types usable as prefix command parameters.
-//!
-//! Many of these implementations defer to [`serenity::ArgumentConvert`].
 
 use super::{pop_string, InvalidBool, MissingAttachment, TooFewArguments};
+use crate::argument_convert::ArgumentConvert;
 use crate::serenity_prelude as serenity;
+use std::str::FromStr;
 
 /// The result of [`PopArgument::pop_from`].
 ///  - If Ok, this is `(remaining, attachment_index, T)`
@@ -38,8 +38,7 @@ impl<'a> PopArgument<'a> for bool {
         ctx: &serenity::Context,
         msg: &serenity::Message,
     ) -> PopArgumentResult<'a, Self> {
-        let (args, string) =
-            pop_string(args).map_err(|_| (TooFewArguments::default().into(), None))?;
+        let (args, string) = pop_string(args).map_err(|e| (e.into(), None))?;
 
         let value = match string.to_ascii_lowercase().trim() {
             "yes" | "y" | "true" | "t" | "1" | "enable" | "on" => true,
@@ -84,26 +83,40 @@ impl<'a> PopArgument<'a> for String {
     }
 }
 
-/// Pops a string and then converts it to `T` using its `ArgumentConvert` implementation.
-async fn pop_from_argumentconvert<'a, T>(
-    args: &'a str,
-    attachment_index: usize,
-    ctx: &serenity::Context,
-    msg: &serenity::Message,
-) -> PopArgumentResult<'a, T>
-where
-    T: serenity::ArgumentConvert + Send,
-    T::Err: std::error::Error + Send + Sync + 'static,
-{
-    let (args, string) = pop_string(args).map_err(|_| (TooFewArguments::default().into(), None))?;
-    let object = T::convert(ctx, msg.guild_id, Some(msg.channel_id), &string)
-        .await
-        .map_err(|e| (e.into(), Some(string)))?;
-
-    Ok((args.trim_start(), attachment_index, object))
+/// Pops a string and then converts it to `T` using its `FromStr` implementation.
+macro_rules! from_str_pop_argument {
+    ( $(
+        $type:ty,
+    )* ) => {
+        $(
+            #[async_trait::async_trait]
+            impl<'a> PopArgument<'a> for $type {
+                async fn pop_from(
+                    args: &'a str,
+                    attachment_index: usize,
+                    ctx: &serenity::Context,
+                    msg: &serenity::Message,
+                ) -> PopArgumentResult<'a, Self>
+                where
+                    Self: FromStr,
+                {
+                    let (args, string) = pop_string(args).map_err(|e| (e.into(), None))?;
+                    let object = Self::from_str(&string).map_err(|e| (e.into(), Some(string)))?;
+                    Ok((args.trim_start(), attachment_index, object))
+                }
+            }
+        )*
+    }
 }
 
-/// Auto-impls `PopArgument` for a type by deferring to [`pop_from_argumentconvert`].
+from_str_pop_argument! {
+    f32, f64,
+    u8, u16, u32, u64,
+    i8, i16, i32, i64,
+    serenity::Mention,
+}
+
+/// Pops a string and then converts it to `T` using its `ArgumentConvert` implementation.
 macro_rules! argumentconvert_pop_argument {
     ( $(
         $( #[cfg(feature = $feature:literal)] )?
@@ -118,8 +131,16 @@ macro_rules! argumentconvert_pop_argument {
                     attachment_index: usize,
                     ctx: &serenity::Context,
                     msg: &serenity::Message,
-                ) -> PopArgumentResult<'a, Self> {
-                    pop_from_argumentconvert(args, attachment_index, ctx, msg).await
+                ) -> PopArgumentResult<'a, Self>
+                where
+                    Self: ArgumentConvert,
+                {
+                    let (args, string) = pop_string(args).map_err(|e| (e.into(), None))?;
+                    let object = Self::convert(ctx, msg.guild_id, Some(msg.channel_id), &string)
+                        .await
+                        .map_err(|e| (e.into(), Some(string)))?;
+
+                    Ok((args.trim_start(), attachment_index, object))
                 }
             }
         )*
@@ -127,20 +148,12 @@ macro_rules! argumentconvert_pop_argument {
 }
 
 argumentconvert_pop_argument! {
-    // Via blanket impl of `ArgumentConvert` for `T: FromStr`
-    f32, f64,
-    u8, u16, u32, u64,
-    i8, i16, i32, i64,
-    serenity::Mention,
-
-    // Via explicit `ArgumentConvert` impls
     serenity::User, serenity::Member,
     serenity::Message,
     serenity::Channel, serenity::GuildChannel,
     serenity::EmojiId, serenity::Emoji,
     serenity::Role,
 
-    #[cfg(feature = "cache")]
     serenity::GuildId,
     #[cfg(feature = "cache")]
     serenity::Guild,
@@ -175,8 +188,7 @@ macro_rules! snowflake_pop_argument {
                 ctx: &serenity::Context,
                 msg: &serenity::Message,
             ) -> PopArgumentResult<'a, Self> {
-                let (args, string) =
-                    pop_string(args).map_err(|_| (TooFewArguments::default().into(), None))?;
+                let (args, string) = pop_string(args).map_err(|e| (e.into(), None))?;
 
                 if let Some(parsed_id) = string
                     .parse()

--- a/src/slash_argument.rs
+++ b/src/slash_argument.rs
@@ -1,6 +1,6 @@
 //! Application command argument handling code
 
-use crate::{serenity_prelude as serenity, BoxFuture, CowVec};
+use crate::{argument_convert::ArgumentConvert, serenity_prelude as serenity, BoxFuture, CowVec};
 
 /// Implement this trait on types that you want to use as a slash command parameter.
 #[async_trait::async_trait]
@@ -33,8 +33,7 @@ async fn extract_via_argumentconvert<T>(
     value: &serenity::ResolvedValue<'_>,
 ) -> Result<T, SlashArgError>
 where
-    T: serenity::ArgumentConvert + Send + Sync,
-    T::Err: std::error::Error + Send + Sync + 'static,
+    T: ArgumentConvert + Send + Sync,
 {
     let string = match value {
         serenity::ResolvedValue::String(str) => *str,


### PR DESCRIPTION
Serenity removed the `ArgumentConvert` trait which poise relied on, so this moves it into poise, essentially unchanged. Removes the blanket impl for `T: FromStr`, since prefix arguments can make use of the `#[string]` attribute now.