### PR TITLE
Fix latest `find_modal_text` breakage from serenity-next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "serenity"
 version = "0.12.4"
-source = "git+https://github.com/serenity-rs/serenity?branch=next#82756d7fa5782c9efcc86392a783d282e48a6869"
+source = "git+https://github.com/serenity-rs/serenity?branch=next#e792c8e6edfa6cf994bdd4e15e020a25f267a187"
 dependencies = [
  "aformat",
  "arrayvec",

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -14,7 +14,7 @@ pub fn find_modal_text(
     for component in data.components.iter_mut() {
         // text inputs can either exist in Labels or Containers
         match component {
-            serenity::Component::Label(label) => match &mut label.component {
+            serenity::ModalComponent::Label(label) => match &mut label.component {
                 serenity::LabelComponent::InputText(input_text) => {
                     if input_text.custom_id == custom_id {
                         return match std::mem::take(&mut input_text.value) {


### PR DESCRIPTION
Fixes breakage caused by the recent serenity-next PR [#3476](https://github.com/serenity-rs/serenity/pull/3476).