### PR TITLE
Check interaction type in command matching.

### DIFF
--- a/src/dispatch/slash.rs
+++ b/src/dispatch/slash.rs
@@ -5,6 +5,7 @@ use crate::serenity_prelude as serenity;
 /// Check if the interaction with the given name and arguments matches any framework command
 fn find_matching_command<'a, 'b, U, E>(
     interaction_name: &str,
+    interaction_kind: serenity::CommandType,
     interaction_options: &'b [serenity::ResolvedOption<'b>],
     commands: &'a [crate::Command<U, E>],
     parent_commands: &mut Vec<&'a crate::Command<U, E>>,
@@ -14,6 +15,19 @@ fn find_matching_command<'a, 'b, U, E>(
             && Some(interaction_name) != cmd.context_menu_name.as_deref()
         {
             return None;
+        }
+
+        // Discord allows commands with the same name as long as they have different types.
+        match interaction_kind {
+            serenity::CommandType::ChatInput => {
+                cmd.slash_action?;
+            }
+            serenity::CommandType::User | serenity::CommandType::Message => {
+                cmd.context_menu_action
+                    .map(serenity::CommandType::from)
+                    .filter(|kind| kind == &interaction_kind)?;
+            }
+            _ => unimplemented!(),
         }
 
         if let Some((sub_name, sub_interaction)) =
@@ -26,7 +40,13 @@ fn find_matching_command<'a, 'b, U, E>(
                 })
         {
             parent_commands.push(cmd);
-            find_matching_command(sub_name, sub_interaction, &cmd.subcommands, parent_commands)
+            find_matching_command(
+                sub_name,
+                interaction_kind,
+                sub_interaction,
+                &cmd.subcommands,
+                parent_commands,
+            )
         } else {
             Some((cmd, interaction_options))
         }
@@ -50,6 +70,7 @@ fn extract_command<'a, U, E>(
 ) -> Result<crate::ApplicationContext<'a, U, E>, crate::FrameworkError<'a, U, E>> {
     let search_result = find_matching_command(
         &interaction.data.name,
+        interaction.data.kind,
         options,
         &framework.options.commands,
         parent_commands,

--- a/src/structs/command.rs
+++ b/src/structs/command.rs
@@ -250,11 +250,7 @@ impl<U, E> Command<U, E> {
 
         // TODO: localization?
         let name = self.context_menu_name.as_deref().unwrap_or(&self.name);
-        let mut builder = serenity::CreateCommand::new(name).kind(match context_menu_action {
-            crate::ContextMenuCommandAction::User(_) => serenity::CommandType::User,
-            crate::ContextMenuCommandAction::Message(_) => serenity::CommandType::Message,
-            crate::ContextMenuCommandAction::__NonExhaustive => unreachable!(),
-        });
+        let mut builder = serenity::CreateCommand::new(name).kind(context_menu_action.into());
 
         if self.guild_only {
             builder = builder.contexts(vec![serenity::InteractionContext::Guild]);

--- a/src/structs/slash.rs
+++ b/src/structs/slash.rs
@@ -109,6 +109,16 @@ impl<U, E> Clone for ContextMenuCommandAction<U, E> {
     }
 }
 
+impl<U, E> From<ContextMenuCommandAction<U, E>> for serenity::CommandType {
+    fn from(value: ContextMenuCommandAction<U, E>) -> Self {
+        match value {
+            ContextMenuCommandAction::User(_) => serenity::CommandType::User,
+            ContextMenuCommandAction::Message(_) => serenity::CommandType::Message,
+            ContextMenuCommandAction::__NonExhaustive => unreachable!(),
+        }
+    }
+}
+
 /// A single drop-down choice in a slash command choice parameter
 #[derive(Debug, Clone)]
 pub struct CommandParameterChoice {


### PR DESCRIPTION
This prevents errors from trying to invoke a message interaction on a user command or vice versa.

Fixes #380.
