### PR TITLE
Fix Clippy and Build docs test errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(doc_nightly, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(doc_nightly, feature(doc_cfg))]
 #![doc(test(attr(deny(deprecated))))]
 // native #[non_exhaustive] is awful because you can't do struct update syntax with it (??)
 #![allow(clippy::manual_non_exhaustive)]
@@ -347,7 +347,7 @@ pub async fn calc(ctx: Context<'_>, expr: String) -> Result<(), Error> {
 
 Can be transformed into
 
-```rust
+```rust,no_run
 # type Error = Box<dyn std::error::Error>;
 # type Context<'a> = poise::Context<'a, (), Error>;
 fn calc_inner(expr: &str) -> Option<f64> {


### PR DESCRIPTION
This fixes the errors in the `Clippy` and `Build docs` tests by:
- Removing `doc_auto_cfg` (feature has been removed; see [here](https://github.com/rust-lang/rust/pull/138907)), which was done for Serenity in October 2025 ([#3428](https://github.com/serenity-rs/serenity/pull/3428/changes))
- Adding `no_run` to the example demonstrating unit testing, in accordance with the recommendation in the [`test_attr_in_doctest` lint details](https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#test_attr_in_doctest)