### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
-[![Build](https://img.shields.io/github/actions/workflow/status/serenity-rs/poise/ci.yml?branch=current)](https://serenity-rs.github.io/poise/)
-[![crates.io](https://img.shields.io/crates/v/poise.svg)](https://crates.io/crates/poise)
-[![Docs](https://img.shields.io/badge/docs-online-informational)](https://docs.rs/poise/)
-[![Docs (git)](https://img.shields.io/badge/docs%20%28git%29-online-informational)](https://serenity-rs.github.io/poise/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Rust: 1.74+](https://img.shields.io/badge/rust-1.74+-93450a)](https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html)
+[![crates.io badge]][crates.io] [![build badge]][build] [![docs badge]][docs] [![current docs badge]][current docs] [![next docs badge]][next docs] [![msrv badge]][msrv] [![license badge]][license] [![guild badge]][guild]
 
 # Poise
 Poise is an opinionated Discord bot framework with a few distinctive features:
@@ -14,26 +9,68 @@ Poise is an opinionated Discord bot framework with a few distinctive features:
 
 # How to use
 
-Most information is in the [API documentation](https://docs.rs/poise/). Also take a
-look at the [examples](examples), especially [`feature_showcase`](examples/feature_showcase), to learn what poise can do.
+Most information is in the [API documentation][docs]. Also take a
+look at the [examples], especially [`feature_showcase`], to learn what poise can do.
 
 If you're using a development version from git directly, you probably want to look at the documentation for the
-[`current`](https://serenity-rs.github.io/poise/current/poise/index.html) or [`next`](https://serenity-rs.github.io/poise/next/poise/index.html) branch instead.
+[`current`][current docs] or [`next`][next docs] branch instead.
 
-For further questions, don't hesitate to join the support server: https://discord.gg/serenity-rs.
+For further questions, don't hesitate to join the [support server][guild].
 
 # Bots using poise
 
 For each bot, there's a list of notable features for you to take inspiration from.
 
-- [Dexscreener Pricebot](https://github.com/keiveulbugs/Dexscreener_pricebot) by [@keiveulbugs](https://github.com/keiveulbugs): embeds, API calls, ephemeral messages
-- [TTS Bot](https://github.com/Discord-TTS/Bot/) by [@GnomedDev](https://github.com/GnomedDev): localization, database, voice
-- [Scripty](https://github.com/scripty-bot/scripty) by [@tazz4843](https://github.com/tazz4843): localization, database, voice
-- [Etternabot](https://github.com/kangalio/Etternabot) by [@kangalio](https://github.com/kangalio): response transformation, variadic and lazy arguments
-- [Rustbot](https://github.com/rust-community-discord/ferrisbot-for-discord) by [@kangalio](https://github.com/kangalio): database, custom prefixes
-- [StatPixel](https://github.com/statpixel-rs/statpixel) by [@matteopolak](https://github.com/matteopolak): modals, buttons, dropdowns, database, localization
-- [CrackTunes](https://github.com/cycle-five/cracktunes) by [@cycle-five](https://github.com/cycle-five): database, voice, custom prefixes, modals.
+- [Dexscreener Pricebot] by [@keiveulbugs]: embeds, API calls, ephemeral messages
+- [TTS Bot] by [@GnomedDev]: localization, database, voice
+- [Scripty] by [@tazz4843]: localization, database, voice
+- [Etternabot] by [@kangalio]: response transformation, variadic and lazy arguments
+- [Ferrisbot] by [@rust-community-discord]: database, custom prefixes
+- [StatPixel] by [@matteopolak]: modals, buttons, dropdowns, database, localization
+- [CrackTunes] by [@cycle-five]: database, voice, custom prefixes, modals
+- [Claude Bot] by [@wyatt-avilla]: database, reactions, slash commands, attachments
 
-You're welcome to add your own bot [via a PR](https://github.com/serenity-rs/poise/compare)!
+You're welcome to add your own bot [via a PR]!
 
-For more projects, see GitHub's [Used By page](https://github.com/serenity-rs/poise/network/dependents).
+For more projects, see GitHub's [Used by] page.
+
+[examples]: examples
+[`feature_showcase`]: examples/feature_showcase
+[via a PR]: https://github.com/serenity-rs/poise/compare
+[Used by]: https://github.com/serenity-rs/poise/network/dependents
+
+<!-- Bots using poise -->
+[Dexscreener Pricebot]: https://github.com/keiveulbugs/Dexscreener_pricebot
+[@keiveulbugs]: https://github.com/keiveulbugs
+[TTS Bot]: https://github.com/Discord-TTS/Bot/
+[@GnomedDev]: https://github.com/GnomedDev
+[Scripty]: https://codeberg.org/scripty-bot/scripty
+[@tazz4843]: https://github.com/tazz4843
+[Etternabot]: https://github.com/kangalio/Etternabot
+[@kangalio]: https://github.com/kangalio
+[Ferrisbot]: https://github.com/rust-community-discord/ferrisbot-for-discord
+[@rust-community-discord]: https://github.com/rust-community-discord
+[StatPixel]: https://github.com/statpixel-rs/statpixel
+[@matteopolak]: https://github.com/matteopolak
+[CrackTunes]: https://github.com/cycle-five/cracktunes
+[@cycle-five]: https://github.com/cycle-five
+[Claude Bot]: https://github.com/wyatt-avilla/claude-discord-bot
+[@wyatt-avilla]: https://github.com/wyatt-avilla
+
+<!-- Badges -->
+[crates.io]: https://crates.io/crates/poise
+[crates.io badge]: https://img.shields.io/crates/v/poise.svg?style=flat-square
+[build]: https://github.com/serenity-rs/poise/actions
+[build badge]: https://img.shields.io/github/actions/workflow/status/serenity-rs/poise/ci.yml?branch=current&style=flat-square
+[docs]: https://docs.rs/poise/
+[docs badge]: https://img.shields.io/badge/docs-online-informational?style=flat-square
+[current docs]: https://serenity-rs.github.io/poise/current/poise/index.html
+[current docs badge]: https://img.shields.io/badge/docs-current-4d76ae.svg?style=flat-square
+[next docs]: https://serenity-rs.github.io/poise/next/poise/index.html
+[next docs badge]: https://img.shields.io/badge/docs-next-4d76ae.svg?style=flat-square
+[msrv]: https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html
+[msrv badge]: https://img.shields.io/badge/rust-1.74+-93450a.svg?style=flat-square
+[license]: LICENSE
+[license badge]: https://img.shields.io/crates/l/poise.svg?style=flat-square&color=yellow
+[guild]: https://discord.gg/serenity-rs
+[guild badge]: https://img.shields.io/discord/381880193251409931.svg?style=flat-square&colorB=7289DA


### PR DESCRIPTION
This PR updates the README badges and their links for consistency across all three serenity-rs projects, [as discussed in the #lib-development channel](https://discord.com/channels/381880193251409931/673965002805477386/1469096181794734386) in Discord.

I also updated the links for Scripty and Ferrisbot (previously Rustbot), and since there was an open PR, I added Claude Bot to the bots list, so this supersedes [#362](https://github.com/serenity-rs/poise/pull/362).