### PR TITLE
Show the error source chain in `builtins::on_error`

### DIFF
--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -12,6 +12,7 @@ mod paginate;
 pub use paginate::*;
 
 use crate::{serenity::CreateAllowedMentions, serenity_prelude as serenity, CreateReply};
+use std::fmt::{self, Display};
 
 /// An error handler that logs errors either via the [`tracing`] crate or via a Discord message. Set
 /// up a logger like tracing subscriber
@@ -29,20 +30,20 @@ use crate::{serenity::CreateAllowedMentions, serenity_prelude as serenity, Creat
 /// }
 /// # };
 /// ```
-pub async fn on_error<U, E: std::fmt::Display + std::fmt::Debug>(
+pub async fn on_error<U, E: Into<Box<dyn std::error::Error + Send + Sync>>>(
     error: crate::FrameworkError<'_, U, E>,
 ) -> Result<(), serenity::Error> {
     match error {
         crate::FrameworkError::Setup { error, .. } => {
-            eprintln!("Error in user data setup: {}", error);
+            eprintln!("Error in user data setup: {}", display_error(error));
         }
         crate::FrameworkError::EventHandler { error, event, .. } => tracing::error!(
             "User event event handler encountered an error on {} event: {}",
             event.snake_case_name(),
-            error
+            display_error(error)
         ),
         crate::FrameworkError::Command { ctx, error } => {
-            let error = error.to_string();
+            let error = display_error(error).to_string();
             eprintln!("An error occured in a command: {}", error);
 
             let mentions = CreateAllowedMentions::new()
@@ -116,14 +117,19 @@ pub async fn on_error<U, E: std::fmt::Display + std::fmt::Debug>(
                 description,
             );
         }
-        crate::FrameworkError::CommandCheckFailed { ctx, error } => {
-            tracing::error!(
-                "A command check failed in command {} for user {}: {:?}",
+        crate::FrameworkError::CommandCheckFailed { ctx, error } => match error {
+            Some(error) => tracing::error!(
+                "A command check failed in command {} for user {}: {}",
                 ctx.command().name,
                 ctx.author().name,
-                error,
-            );
-        }
+                display_error(error),
+            ),
+            None => tracing::error!(
+                "A command check failed in command {} for user {}",
+                ctx.command().name,
+                ctx.author().name,
+            ),
+        },
         crate::FrameworkError::CooldownHit {
             remaining_cooldown,
             ctx,
@@ -195,7 +201,7 @@ pub async fn on_error<U, E: std::fmt::Display + std::fmt::Debug>(
             tracing::error!(
                 "Dynamic prefix failed for message {:?}: {}",
                 msg.content,
-                error
+                display_error(error)
             );
         }
         crate::FrameworkError::UnknownCommand {
@@ -213,7 +219,10 @@ pub async fn on_error<U, E: std::fmt::Display + std::fmt::Debug>(
             tracing::warn!("received unknown interaction \"{}\"", interaction.data.name);
         }
         crate::FrameworkError::NonCommandMessage { error, .. } => {
-            tracing::warn!("error in non-command message handler: {}", error);
+            tracing::warn!(
+                "error in non-command message handler: {}",
+                display_error(error)
+            );
         }
         crate::FrameworkError::__NonExhaustive(unreachable) => match unreachable {},
     }
@@ -327,4 +336,27 @@ pub async fn servers<U, E>(ctx: crate::Context<'_, U, E>) -> Result<(), serenity
 
     ctx.send(reply).await?;
     Ok(())
+}
+
+/// Helper function to display an `impl Into<Box<dyn std::error::Error>>` and its chain of causes.
+fn display_error(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> impl Display {
+    struct DisplayError(Box<dyn std::error::Error + Send + Sync>);
+
+    impl Display for DisplayError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut e: &(dyn std::error::Error + 'static) = &*self.0;
+
+            Display::fmt(e, f)?;
+
+            while let Some(new_e) = e.source() {
+                f.write_str(": ")?;
+                Display::fmt(new_e, f)?;
+                e = new_e;
+            }
+
+            Ok(())
+        }
+    }
+
+    DisplayError(e.into())
 }

--- a/src/structs/framework_options.rs
+++ b/src/structs/framework_options.rs
@@ -92,7 +92,7 @@ impl<U, E> FrameworkOptions<U, E> {
 impl<U, E> Default for FrameworkOptions<U, E>
 where
     U: Send + Sync,
-    E: std::fmt::Display + std::fmt::Debug + Send,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + Send,
 {
     fn default() -> Self {
         #[allow(deprecated)] // we need to set the listener field


### PR DESCRIPTION
It’s more useful if the entire error source chain is shown instead of just the first error. To achieve this, we accept `E: Into<Box<dyn std::error::Error + Send + Sync>>`. Importantly, this trait is implemented for:
- any type `E: 'static + Send + Sync + Error`
- `Box<dyn std::error::Error + Send + Sync>`
- `anyhow::Error`

Because of this, in my opinion it’s not too much more onerous of a bound than `E: Debug + Display`.