### PR TITLE
Support `#[string]` in slash commands

### DIFF
--- a/examples/feature_showcase/parameter_attributes.rs
+++ b/examples/feature_showcase/parameter_attributes.rs
@@ -92,7 +92,7 @@ pub async fn test_flag(ctx: Context<'_>, #[flag] flag: bool) -> Result<(), Error
 }
 
 /// Demonstrates `#[string]`
-#[poise::command(prefix_command)]
+#[poise::command(prefix_command, slash_command)]
 pub async fn test_fromstr(
     ctx: Context<'_>,
     #[string] ip_addr: std::net::IpAddr,

--- a/macros/src/command/slash.rs
+++ b/macros/src/command/slash.rs
@@ -78,6 +78,8 @@ pub fn generate_parameters(inv: &Invocation) -> Result<Vec<proc_macro2::TokenStr
             true => {
                 if let Some(_choices) = &param.args.choices {
                     quote::quote! { Some(|o| o.kind(::poise::serenity_prelude::CommandOptionType::Integer)) }
+                } else if param.args.string {
+                    quote::quote! { Some(|o| o.kind(::poise::serenity_prelude::CommandOptionType::String)) }
                 } else {
                     quote::quote! { Some(|o| {
                         <#type_ as ::poise::SlashArgument>::create(o)
@@ -100,6 +102,8 @@ pub fn generate_parameters(inv: &Invocation) -> Result<Vec<proc_macro2::TokenStr
                     localizations: Cow::Borrowed(&[]),
                     __non_exhaustive: (),
                 } ),*]) }
+            } else if param.args.string {
+                quote::quote! { Cow::Borrowed(&[]) }
             } else {
                 quote::quote! { <#type_ as ::poise::SlashArgument>::choices() }
             }
@@ -194,8 +198,8 @@ pub fn generate_slash_action(inv: &Invocation) -> Result<proc_macro2::TokenStrea
 }
 
 fn parse_slash_param(param: &CommandParameter) -> proc_macro2::TokenStream {
-    fn extract_slash_argument(ty: &syn::Type) -> syn::Expr {
-        syn::parse_quote! {
+    fn extract_slash_argument(ty: impl quote::ToTokens) -> proc_macro2::TokenStream {
+        quote::quote! {
             <#ty as ::poise::SlashArgument>::extract(
                 serenity_ctx,
                 interaction,
@@ -210,76 +214,64 @@ fn parse_slash_param(param: &CommandParameter) -> proc_macro2::TokenStream {
 
     if param.args.flag {
         // Extract #[flag]
-        let extract = extract_slash_argument(&syn::parse_quote! { bool });
-        quote::quote! {
+        let extract = extract_slash_argument(quote::quote! { bool });
+        return quote::quote! {
             match args.iter().find(|arg| arg.name == #name) {
                 Some(arg) => #extract,
                 None => false,
             }
-        }
-    } else if let Some(choices) = &param.args.choices {
+        };
+    }
+
+    enum Wrapper {
+        Option,
+        Vec,
+        Plain,
+    }
+
+    let (wrapper, ty) = if let Some(ty) = unwrap_generic(ty, "Option") {
+        (Wrapper::Option, ty)
+    } else if let Some(ty) = unwrap_generic(ty, "Vec") {
+        (Wrapper::Vec, ty)
+    } else {
+        (Wrapper::Plain, ty)
+    };
+
+    let extract = if let Some(choices) = &param.args.choices {
         // Extract #[choices(...)]
         let choice_indices = (0..choices.0.len()).map(syn::Index::from);
         let choice_vals = &choices.0;
 
-        // Allow `Option<T>` for choice parameters
-        let (choices, not_found) = if unwrap_generic(ty, "Option").is_some() {
-            (
-                quote::quote! { #( #choice_indices => Some(#choice_vals), )* },
-                quote::quote! { None },
-            )
-        } else {
-            (
-                quote::quote! { #( #choice_indices => #choice_vals, )* },
-                quote::quote! {
+        quote::quote! {{
+            let ::poise::serenity_prelude::ResolvedValue::Integer(index) = arg.value else {
+                return Err(::poise::SlashArgError::new_command_structure_mismatch(
+                    "expected integer, as the index for an inline choice parameter")
+                );
+            };
+            match index {
+                #( #choice_indices => #choice_vals, )*
+                _ => {
                     return Err(::poise::SlashArgError::new_command_structure_mismatch(
-                        "a required argument is missing"
+                        "out of range index for inline choice parameter"
                     ));
-                },
-            )
-        };
-
-        quote::quote! {
-            if let Some(arg) = args.iter().find(|arg| arg.name == #name) {
-                let ::poise::serenity_prelude::ResolvedValue::Integer(index) = arg.value else {
-                    return Err(::poise::SlashArgError::new_command_structure_mismatch(
-                        "expected integer, as the index for an inline choice parameter")
-                    );
-                };
-                match index {
-                    #choices
-                    _ => {
-                        return Err(::poise::SlashArgError::new_command_structure_mismatch(
-                            "out of range index for inline choice parameter"
-                        ));
-                    }
                 }
-            } else {
-                #not_found
             }
-        }
-    } else if let Some(ty) = unwrap_generic(ty, "Option") {
-        // Extract Option<T>
-        let extract = extract_slash_argument(ty);
-        quote::quote! {
-            match args.iter().find(|arg| arg.name == #name) {
-                Some(arg) => Some(#extract),
-                None => None,
-            }
-        }
-    } else if let Some(ty) = unwrap_generic(ty, "Vec") {
-        // Extract Vec<T> (slash commands don't support variadic arguments right now
-        let extract = extract_slash_argument(ty);
-        quote::quote! {
-            match args.iter().find(|arg| arg.name == #name) {
-                Some(arg) => vec![#extract],
-                None => vec![]
-            }
-        }
+        }}
+    } else if param.args.string {
+        let extract = extract_slash_argument(quote::quote!(String));
+
+        quote::quote! {{
+            let input = #extract;
+            <#ty as ::std::str::FromStr>::from_str(&input)
+                .map_err(|e| ::poise::SlashArgError::new_parse(e.into(), input))?
+        }}
     } else {
         // Extract T
-        let extract = extract_slash_argument(ty);
-        quote::quote! {
+        extract_slash_argument(ty)
+    };
+
+    match wrapper {
+        Wrapper::Plain => quote::quote! {
             match args.iter().find(|arg| arg.name == #name) {
                 Some(arg) => #extract,
                 None => {
@@ -288,7 +280,20 @@ fn parse_slash_param(param: &CommandParameter) -> proc_macro2::TokenStream {
                     ));
                 }
             }
-        }
+        },
+        Wrapper::Option => quote::quote! {
+            match args.iter().find(|arg| arg.name == #name) {
+                Some(arg) => Some(#extract),
+                None => None,
+            }
+        },
+        // Slash commands don't support variadic arguments right now
+        Wrapper::Vec => quote::quote! {
+            match args.iter().find(|arg| arg.name == #name) {
+                Some(arg) => vec![#extract],
+                None => vec![],
+            }
+        },
     }
 }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -113,7 +113,7 @@ attributes you can use on parameters:
 - `#[string]`: Indicates that a type implements `FromStr` and should be parsed from a string argument.
 - `#[rest]`: Use the entire rest of the message for this parameter (prefix-only)
 - `#[lazy]`: Can be used on Option and Vec parameters and is equivalent to regular expressions' laziness (prefix-only)
-- `#[flag]`: Can be used on a bool parameter make it optional and default to `false`; additionally,
+- `#[flag]`: Can be used on a bool parameter to make it optional and default to `false`; additionally,
   in prefix commands only, the user can pass in the parameter name literally to set it to `true`.
     - For example with `async fn my_command(ctx: Context<'_>, #[flag] my_flag: bool)`, `~my_command` or `/my_command` would set `my_flag` to false, while `~my_command my_flag` would set `my_flag` to true
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -109,12 +109,13 @@ attributes you can use on parameters:
 - `#[min_length = 0]`: Minimum length for this string parameter (slash-only)
 - `#[max_length = 1]`: Maximum length for this string parameter (slash-only)
 
-## Parser settings (prefix only)
+## Parser settings
 - `#[string]`: Indicates that a type implements `FromStr` and should be parsed from a string argument.
 - `#[rest]`: Use the entire rest of the message for this parameter (prefix-only)
 - `#[lazy]`: Can be used on Option and Vec parameters and is equivalent to regular expressions' laziness (prefix-only)
-- `#[flag]`: Can be used on a bool parameter to set the bool to true if the user typed the parameter name literally (prefix-only)
+- `#[flag]`: Can be used on a bool parameter to set the bool to true if the user typed the parameter name literally
     - For example with `async fn my_command(ctx: Context<'_>, #[flag] my_flag: bool)`, `~my_command` would set my_flag to false, and `~my_command my_flag` would set my_flag to true
+    - On slash commands, this makes the parameter optional and default to `false`.
 
 # Help text
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -113,9 +113,9 @@ attributes you can use on parameters:
 - `#[string]`: Indicates that a type implements `FromStr` and should be parsed from a string argument.
 - `#[rest]`: Use the entire rest of the message for this parameter (prefix-only)
 - `#[lazy]`: Can be used on Option and Vec parameters and is equivalent to regular expressions' laziness (prefix-only)
-- `#[flag]`: Can be used on a bool parameter to set the bool to true if the user typed the parameter name literally
-    - For example with `async fn my_command(ctx: Context<'_>, #[flag] my_flag: bool)`, `~my_command` would set my_flag to false, and `~my_command my_flag` would set my_flag to true
-    - On slash commands, this makes the parameter optional and default to `false`.
+- `#[flag]`: Can be used on a bool parameter make it optional and default to `false`; additionally,
+  in prefix commands only, the user can pass in the parameter name literally to set it to `true`.
+    - For example with `async fn my_command(ctx: Context<'_>, #[flag] my_flag: bool)`, `~my_command` or `/my_command` would set `my_flag` to false, while `~my_command my_flag` would set `my_flag` to true
 
 # Help text
 

--- a/src/slash_argument.rs
+++ b/src/slash_argument.rs
@@ -231,6 +231,10 @@ impl SlashArgError {
         Self::CommandStructureMismatch { description }
     }
 
+    pub fn new_parse(error: Box<dyn std::error::Error + Send + Sync>, input: String) -> Self {
+        Self::Parse { error, input }
+    }
+
     pub fn to_framework_error<U, E>(
         self,
         ctx: crate::ApplicationContext<'_, U, E>,


### PR DESCRIPTION
This allows slash command parameters to use `FromStr` instead of having to implement `SlashArgument`.